### PR TITLE
デザインプレビューと機能仕様書の詳細化

### DIFF
--- a/docs/design/preview.html
+++ b/docs/design/preview.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="theme-color" content="#0f0f10">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<title>trip-road デザインプレビュー</title>
+<style>
+:root {
+  --color-background-secondary: #1c1c1e;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic", "Meiryo", sans-serif;
+  --border-radius-lg: 16px;
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  padding: 0;
+  background: #000;
+  font-family: var(--font-sans);
+}
+body {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (max-width: 420px) {
+  body { align-items: flex-start; }
+}
+</style>
+</head>
+<body>
+
+<h2 class="sr-only">trip-road のメイン画面モックアップ。iPhone 縦画面に、上部ステータスバー、地図、下部の土地解説カードを配置したダークテーマのデザイン。</h2>
+
+<div style="background: var(--color-background-secondary); padding: 2rem 1rem; border-radius: var(--border-radius-lg); display: flex; justify-content: center;">
+
+  <div style="width: 375px; height: 780px; background: #0f0f10; border-radius: 44px; border: 8px solid #1c1c1e; box-shadow: 0 0 0 2px #000; overflow: hidden; position: relative; font-family: var(--font-sans); color: #f5f5f7;">
+
+    <div style="height: 44px; display: flex; justify-content: space-between; align-items: center; padding: 0 24px; font-size: 15px; font-weight: 500; color: #f5f5f7; background: #0f0f10; position: relative; z-index: 10;">
+      <span>9:41</span>
+      <div style="display: flex; align-items: center; gap: 6px;">
+        <svg width="18" height="12" viewBox="0 0 18 12" fill="none"><path d="M1 9 L1 11 M5 7 L5 11 M9 4 L9 11 M13 1 L13 11" stroke="#f5f5f7" stroke-width="1.5" stroke-linecap="round"/></svg>
+        <svg width="26" height="12" viewBox="0 0 26 12" fill="none"><rect x="1" y="2" width="20" height="8" rx="2" stroke="#f5f5f7" stroke-width="1" fill="none"/><rect x="3" y="4" width="16" height="4" rx="1" fill="#f5f5f7"/><rect x="22" y="4" width="2" height="4" rx="0.5" fill="#f5f5f7"/></svg>
+      </div>
+    </div>
+
+    <div style="position: absolute; top: 56px; left: 16px; right: 16px; z-index: 5; display: flex; justify-content: space-between; align-items: flex-start; gap: 8px;">
+
+      <div style="background: rgba(22,22,24,0.85); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 0.5px solid rgba(255,255,255,0.08); border-radius: 14px; padding: 10px 14px; display: flex; align-items: center; gap: 10px;">
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none"><circle cx="9" cy="9" r="7" stroke="#9fe1cb" stroke-width="1.2" fill="none"/><circle cx="9" cy="9" r="2.5" fill="#9fe1cb"/></svg>
+        <div>
+          <div style="font-size: 10px; letter-spacing: 0.08em; color: #7a7a80; text-transform: uppercase;">いま</div>
+          <div style="font-size: 15px; font-weight: 500; color: #f5f5f7; line-height: 1.2; margin-top: 1px;">神奈川県 相模原市緑区</div>
+        </div>
+      </div>
+
+      <div style="background: rgba(22,22,24,0.85); backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px); border: 0.5px solid rgba(255,255,255,0.08); border-radius: 14px; padding: 10px 12px; min-width: 62px; text-align: center;">
+        <div style="font-size: 10px; letter-spacing: 0.08em; color: #7a7a80; text-transform: uppercase;">制覇</div>
+        <div style="font-size: 17px; font-weight: 500; color: #f5f5f7; line-height: 1.2; margin-top: 1px;">47<span style="font-size: 11px; color: #7a7a80; margin-left: 2px;">市町村</span></div>
+      </div>
+    </div>
+
+    <div style="position: absolute; top: 44px; left: 0; right: 0; bottom: 320px; background: #18181a; overflow: hidden;">
+
+      <svg width="100%" height="100%" viewBox="0 0 360 420" preserveAspectRatio="xMidYMid slice" style="display: block;">
+        <defs>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#222225" stroke-width="0.5"/>
+          </pattern>
+        </defs>
+        <rect width="360" height="420" fill="#1a1a1c"/>
+        <rect width="360" height="420" fill="url(#grid)"/>
+
+        <path d="M 20 140 Q 80 120 140 150 T 260 170 L 300 190 L 340 220" fill="none" stroke="#2a2a2e" stroke-width="20" stroke-linecap="round"/>
+        <path d="M 40 300 Q 120 280 200 310 T 340 340" fill="none" stroke="#2a2a2e" stroke-width="16" stroke-linecap="round"/>
+        <path d="M 100 50 L 120 180 L 140 280 L 180 380" fill="none" stroke="#2a2a2e" stroke-width="14" stroke-linecap="round"/>
+
+        <path d="M 0 240 Q 60 210 130 230 Q 200 250 270 220 Q 320 200 360 210" fill="none" stroke="#25353a" stroke-width="3" opacity="0.6"/>
+
+        <path d="M 40 360 L 70 340 L 90 320 L 110 300 L 130 285 L 155 270 L 180 255 L 200 240 L 220 230 L 240 220" fill="none" stroke="#5dcaa5" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.9"/>
+        <path d="M 40 360 L 70 340 L 90 320 L 110 300 L 130 285 L 155 270 L 180 255 L 200 240 L 220 230 L 240 220" fill="none" stroke="#5dcaa5" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" opacity="0.15"/>
+
+        <circle cx="40" cy="360" r="4" fill="#5dcaa5" opacity="0.7"/>
+        <circle cx="110" cy="300" r="4" fill="#5dcaa5" opacity="0.8"/>
+        <circle cx="180" cy="255" r="4" fill="#5dcaa5" opacity="0.9"/>
+
+        <circle cx="240" cy="220" r="18" fill="#5dcaa5" opacity="0.15"/>
+        <circle cx="240" cy="220" r="11" fill="#5dcaa5" opacity="0.28"/>
+        <circle cx="240" cy="220" r="6" fill="#5dcaa5"/>
+        <circle cx="240" cy="220" r="2.5" fill="#0f0f10"/>
+      </svg>
+
+      <div style="position: absolute; bottom: 12px; right: 12px; background: rgba(22,22,24,0.9); padding: 4px 8px; border-radius: 6px; font-size: 9px; color: #6a6a70; letter-spacing: 0.02em;">出典：地理院タイル</div>
+    </div>
+
+    <div style="position: absolute; bottom: 44px; left: 0; right: 0; background: linear-gradient(180deg, rgba(15,15,16,0) 0%, #0f0f10 14%, #0f0f10 100%); padding: 28px 20px 20px; z-index: 6;">
+
+      <div style="width: 36px; height: 4px; background: #3a3a3e; border-radius: 2px; margin: 0 auto 18px;"></div>
+
+      <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 18px;">
+        <div>
+          <div style="font-size: 11px; letter-spacing: 0.12em; color: #9fe1cb; text-transform: uppercase; margin-bottom: 6px;">SAGAMIHARA · MIDORI</div>
+          <div style="font-size: 24px; font-weight: 500; color: #f5f5f7; line-height: 1.1; letter-spacing: -0.01em;">相模原市 緑区</div>
+        </div>
+        <div style="text-align: right;">
+          <div style="font-size: 10px; letter-spacing: 0.1em; color: #6a6a70; text-transform: uppercase; margin-bottom: 2px;">SPEED</div>
+          <div style="display: flex; align-items: baseline; gap: 4px; justify-content: flex-end;">
+            <span style="font-size: 28px; font-weight: 500; color: #f5f5f7; font-variant-numeric: tabular-nums; line-height: 1;">62</span>
+            <span style="font-size: 12px; color: #7a7a80;">km/h</span>
+          </div>
+        </div>
+      </div>
+
+      <div style="background: rgba(255,255,255,0.03); border: 0.5px solid rgba(255,255,255,0.06); border-radius: 16px; padding: 16px 18px; margin-bottom: 14px;">
+        <div style="display: flex; align-items: center; gap: 6px; margin-bottom: 10px;">
+          <div style="width: 14px; height: 1px; background: #9fe1cb;"></div>
+          <span style="font-size: 10px; letter-spacing: 0.14em; color: #9fe1cb; text-transform: uppercase;">土地のたより</span>
+        </div>
+        <p style="font-size: 14px; line-height: 1.75; color: #d8d8dc; margin: 0; font-feature-settings: 'palt';">緑区は津久井湖や相模湖を抱く、山と水の町です。春は桜、夏は鮎釣り、秋には中津川の紅葉が渓谷を染めます。津久井やまゆりラインの沿道では、地場の柚子やこんにゃくが並ぶ直売所が旅人を迎えてくれます。</p>
+      </div>
+
+      <div style="display: flex; justify-content: space-between; align-items: center;">
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none"><circle cx="5" cy="5" r="4" stroke="#6a6a70" stroke-width="0.8" fill="none"/><path d="M5 3 L5 5.5 L6.5 6.5" stroke="#6a6a70" stroke-width="0.8" stroke-linecap="round"/></svg>
+          <span style="font-size: 10px; color: #6a6a70;">情報は目安です</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <div style="width: 6px; height: 6px; border-radius: 50%; background: #5dcaa5;"></div>
+          <span style="font-size: 10px; color: #9fe1cb; letter-spacing: 0.04em;">GPS 受信中</span>
+        </div>
+      </div>
+    </div>
+
+    <div style="position: absolute; bottom: 0; left: 0; right: 0; height: 44px; display: flex; justify-content: center; align-items: flex-end; padding-bottom: 8px; background: #0f0f10;">
+      <div style="width: 134px; height: 5px; background: #f5f5f7; border-radius: 3px;"></div>
+    </div>
+
+  </div>
+</div>
+</body>
+</html>

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,28 +1,623 @@
 # trip-road 機能仕様書
 
-**バージョン**: 0.1（作成中）  
-**ステータス**: plan.md レビュー完了後に詳細化予定
+**バージョン**: 1.0  
+**作成日**: 2026-04-22  
+**ステータス**: 実装着手前の詳細化版  
+**原典**: `docs/plan.md` / `docs/design/trip_road_main_screen_mockup.html`
 
 ---
 
-## 本ドキュメントの位置づけ
+## 1. 本仕様書の位置づけと優先順位
 
-`docs/plan.md` がレビュー完了次第、以下を含む詳細仕様として作成します。
+memo.txt の要件定義を、ブレインストーミング決定事項とデザインカンプで詳細化した実装可能な仕様書である。矛盾があった場合は以下の優先順位で解決する。
 
-- memo.txt（要件定義書 v0.3）の拡張版として、ブレスト確定事項を反映
-- 画面仕様（Canva MCP モックアップ画像 + テキストワイヤーフレーム）
-- データ仕様詳細（GeoJSON形式、localStorage データ構造、API リクエスト/レスポンス形式）
-- Workers API エンドポイント仕様
-- プロンプトテンプレート（Claude Haiku 向け、厳格化ルール込み）
-- エラーハンドリング詳細
-- テスト戦略（GPS モックの方法、地域別動作確認手順）
+1. `docs/design/trip_road_main_screen_mockup.html`（UI・画面仕様の原典）
+2. **本ファイル `docs/spec.md`**（機能・API・データの原典）
+3. `docs/plan.md`（方針・マイルストーン）
+4. `memo.txt`（元の要件、参考扱い）
 
 ---
 
-## 暫定の参照先
+## 2. 画面仕様
 
-現時点で確定している設計事項は以下を参照：
+### 2.1 メイン画面
 
-- 全体設計・マイルストーン: `docs/plan.md`
-- 決定事項・トレードオフ: `docs/knowledge.md`
-- 元の要件書: `memo.txt`
+モックアップ `docs/design/trip_road_main_screen_mockup.html` を原典とする。iPhone 縦画面（基準 375×812、SafeArea 考慮）を前提。
+
+構成要素（上から）：
+- **iOS システムステータスバー**（44px、iOS 描画、PWA では自前描画せず）
+- **上部フロート帯**（top: 56px、z-index: 5、glassmorphism）
+  - 左「いま」チップ: ティール円形ピン + ラベル「いま」（10px uppercase）+ 市町村名（15px）
+  - 右「制覇」チップ: ラベル「制覇」+ 数字（17px）+ 「市町村」（11px）
+- **地図エリア**（top: 44px 〜 bottom: 320px、背景 `#18181a`）
+  - 地理院タイル + 軌跡ポリライン + 現在地マーカー
+  - 右下に「出典：地理院タイル」固定
+- **下部カード**（bottom: 44px 〜、`#0f0f10` グラデーション背景）
+  - ドラッグハンドル表示（装飾、機能なし）
+  - 市町村名（24px、weight: 500）+ 速度（28px、tabular-nums）を左右に
+  - 「土地のたより」カード（rounded 16px、`rgba(255,255,255,0.03)` 背景、`rgba(255,255,255,0.06)` 0.5px border）
+  - フッター行: 「情報は目安です」（左、10px `#6a6a70`）+ GPS 受信中（右、ティール点 + テキスト）
+- **iOS ホームインジケーター領域**（44px、iOS 描画）
+
+### 2.2 パスワード入力画面
+
+モックアップ未作成のため本仕様で定義。メイン画面の設計言語を踏襲。
+
+```
+┌─────────────────────────┐
+│                         │
+│         (空白)          │
+│                         │
+│      trip-road          │ ← ティール `#9fe1cb`、12〜14px、uppercase、letter-spacing 0.14em
+│    旅のお供、始めます     │ ← `#7a7a80`、11px
+│                         │
+│   [  合言葉   ] ← ■     │ ← 入力フィールド 260×44、rounded 12px
+│                         │
+│   [   はじめる   ]      │ ← ティール `#5dcaa5` ボタン 260×44、文字 `#0f0f10`
+│                         │
+│                         │
+└─────────────────────────┘
+    背景 `#0f0f10`
+```
+
+**入力フィールド**:
+- `<input type="password" autocomplete="off" spellcheck="false">`
+- 背景 `rgba(255,255,255,0.05)`、border 0.5px solid `rgba(255,255,255,0.08)`
+- rounded 12px、padding `0 16px`、文字色 `#f5f5f7`、placeholder 色 `#7a7a80`
+- focus 時: border-color を `#5dcaa5` に、transition 150ms
+
+**送信ボタン**:
+- `<button type="submit">はじめる</button>`
+- 入力が空のとき `opacity: 0.4; pointer-events: none;`
+- tap 時は `opacity: 0.8` のプレス感
+
+**エラー表示**:
+- フィールド下に 8px 空けて表示、`#e08080` 11px
+- 文言: 「パスワードが違います」
+- 401 受信直後に表示、次の入力タップで消去
+
+### 2.3 エラー状態
+
+**(a) GPS 権限拒否**:
+- 上部「いま」チップ: 市町村名部分を「位置情報の許可が必要です」（14px）
+- 「土地のたより」カード本文: 「iPhone の設定 → trip-road → 位置情報 を「App の使用中のみ」に設定してください」（14px line-height 1.6）
+- 地図: 空、または薄暗い灰色一色（`#18181a`）
+
+**(b) 市町村未確定**（P-in-P とGSIフォールバック両方失敗）:
+- 「いま」チップ: 「位置を確認中...」（`#7a7a80`）
+- 地図: 現在地ピンと軌跡は表示、追従
+- 「土地のたより」カード: ラベル非表示、本文空
+
+**(c) LLM 呼出失敗**（3回指数バックオフ後）:
+- 上部フロートと地図は通常通り
+- 「土地のたより」カード:
+  - ラベル「土地のたより」は維持
+  - 本文の代わりに注記「解説を取得できませんでした」（`#7a7a80`、12px）
+  - 再試行ボタンなし（次の市町村切替で自動回復）
+
+### 2.4 初期状態（GPS 測位前）
+
+- 「いま」チップ: 「現在地を取得中...」（`#7a7a80`、15px）
+- 「制覇」チップ: 既存 `localStorage.visited` のキー数、無ければ「0」
+- 地図: 中心 `[35.5, 138]`、ズーム 5（日本全体ビュー）
+- 「土地のたより」カード: ラベル・本文ともに空
+- 速度: `--`
+- GPS 受信中インジケーター: 脈動なし灰色点（`#6a6a70`）、文言「GPS 測位中」
+
+### 2.5 ローディング状態（LLM 呼出中）
+
+- 上部・地図は通常通り
+- 「土地のたより」カード:
+  - ラベル「土地のたより」表示
+  - 本文の代わりにスケルトン 3 本（幅 100% / 100% / 60%、高さ 12px、背景 `rgba(255,255,255,0.06)`、rounded 3px、垂直 8px 間隔、シマー animation 1.5s）
+- 画面は操作可能
+
+### 2.6 免責・出典表示
+
+常時表示：
+- 下部カードフッター左: 「情報は目安です」（10px `#6a6a70`）
+- 地図右下: 「出典：地理院タイル」（9px、`rgba(22,22,24,0.9)` 背景）
+
+初回起動時のみ表示（将来検討）：
+- 「国土数値情報（行政区域データ）（国土交通省）を加工して作成」
+- Phase 4 で配置場所を決定（About モーダル 等）
+
+---
+
+## 3. 機能仕様詳細
+
+### 3.1 GPS 取得と現在地表示
+
+```javascript
+navigator.geolocation.watchPosition(
+  onPositionSuccess,
+  onPositionError,
+  { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+);
+```
+
+`onPositionSuccess(position)` の処理：
+1. 速度表示更新: `coords.speed` が数値なら `Math.round(coords.speed * 3.6)`、null/負なら `--`
+2. 地図マーカー移動 + `map.setView([lat, lon], 14, { animate: true, duration: 0.3 })`
+3. 軌跡 `track[]` に `{ lat, lon, ts: Date.now() }` を push、localStorage 保存
+4. 市町村判定（3.2）を呼出
+
+`onPositionError(error)` の処理（`error.code`）：
+- `1` PERMISSION_DENIED: 2.3(a) GPS 権限拒否画面へ遷移、watchPosition 停止
+- `2` POSITION_UNAVAILABLE: 画面維持、ログに記録、次の成功を待つ
+- `3` TIMEOUT: 画面維持、次の成功を待つ
+
+### 3.2 市町村の自動判定
+
+判定フロー（3段階）：
+
+**ステップ1**: 現在の市町村ポリゴンに対する Turf.js 判定
+```javascript
+turf.booleanPointInPolygon(turf.point([lon, lat]), currentMuniPolygon)
+```
+- true → 状態維持、終了
+- false → ステップ2
+
+**ステップ2**: 隣接市町村（`adjacency.json`）のうちロード済みポリゴンに対する判定
+```javascript
+const neighbors = adjacency[currentMuniCd] ?? [];
+for (const code of neighbors) {
+  if (!loadedPolygons[code]) continue;
+  if (turf.booleanPointInPolygon(pt, loadedPolygons[code])) {
+    return code;  // 切替処理へ
+  }
+}
+```
+- ヒット → 市町村切替処理
+- どれもヒットせず → ステップ3
+
+**ステップ3**: 国土地理院逆ジオコーダ
+```
+GET https://mreversegeocoder.gsi.go.jp/reverse-geocoder/LonLatToAddress?lat={lat}&lon={lon}
+```
+- レスポンスから `results.muniCd` を取得
+- `/municipalities/{muniCd}.geojson` を動的ロード
+- `loadedPolygons[muniCd]` に登録、切替処理へ
+
+**市町村切替処理**：
+1. 新市町村コードを `currentMuniCd` にセット、localStorage 保存
+2. `visited[code]` に未登録なら登録（制覇カウント +1、UI 更新）
+3. `adjacency[code]` から隣接コード一覧を取得
+4. 未ロード隣接を `Promise.all` で並列 fetch（fire-and-forget でもよい）
+5. 季節判定: `getSeason(new Date())`
+6. `visited[code].descriptions[season]` 確認
+   - 存在 → そのテキストを「土地のたより」にフェードイン表示、API 呼出なし
+   - 未存在 → LLM 呼出フロー（3.3）
+
+**GSI フォールバック発動の追加条件**：
+- アプリ起動直後、`track[]` 末尾から現在位置が 500m 以上離れている
+- P-in-P 結果が直近 3 回連続で同一市町村コードに収束しない
+
+### 3.3 土地のたより生成（LLM）
+
+**季節判定**：
+```javascript
+function getSeason(date) {
+  const m = date.getMonth() + 1;
+  if (m >= 3 && m <= 5) return 'spring';
+  if (m >= 6 && m <= 8) return 'summer';
+  if (m >= 9 && m <= 11) return 'autumn';
+  return 'winter';
+}
+```
+
+**呼出フロー**：
+1. ローディング状態（2.5）に遷移
+2. `POST {WORKERS_URL}/api/describe`（本仕様 5 節参照）
+3. 成功 → `visited[code].descriptions[season]` にキャッシュ、カードにフェードイン（200ms opacity 0→1）
+4. 失敗 → 1秒後に再試行、2秒後に再試行、4秒後に再試行。最終失敗時は 2.3(c) LLM 失敗状態
+
+**リトライ判定**：
+- 500/502/503/504 および fetch reject → リトライ対象
+- 401 → パスワード画面に戻す（3.6 参照）、リトライしない
+- 400/404 → エラー状態、リトライしない
+
+### 3.4 地図表示と通過軌跡
+
+**Leaflet 初期化**：
+```javascript
+const map = L.map('map', {
+  center: [35.5, 138],
+  zoom: 5,
+  zoomControl: false,          // ズームボタン非表示（モバイル優先）
+  attributionControl: false    // 出典は手動で右下に
+});
+
+L.tileLayer('https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png', {
+  maxZoom: 18,
+  tileSize: 256
+}).addTo(map);
+```
+
+**追従モード（常時 ON）**：
+- GPS 更新ごとに `map.setView([lat, lon], currentZoom, { animate: true, duration: 0.3 })`
+- ズーム 14 を基本とし、初回測位時のみズームイン animate（5 → 14）
+
+**現在地マーカー**：
+- `L.divIcon` で SVG（ティール外周 `#9fe1cb` + 内芯 `#5dcaa5`、直径 18px）
+- 更新時: `marker.setLatLng([lat, lon])`
+
+**軌跡ポリライン**：
+```javascript
+const trackLine = L.polyline([], {
+  color: '#5dcaa5',
+  weight: 3,
+  opacity: 0.9,
+  lineCap: 'round',
+  lineJoin: 'round'
+}).addTo(map);
+```
+- GPS 更新ごとに `trackLine.addLatLng([lat, lon])`
+- localStorage 復元時は初期化時に `trackLine.setLatLngs(track.map(t => [t.lat, t.lon]))`
+
+### 3.5 制覇カウント
+
+- `Object.keys(visited).length` が制覇数
+- 上部右フロートチップに表示（`{数字} <span>市町村</span>`）
+- 新市町村切替時に自動更新
+
+### 3.6 パスワード認証
+
+**フロー**：
+1. アプリ起動時、`localStorage.getItem('password')` 確認
+2. 未設定 → パスワード画面（2.2）表示
+3. ユーザ入力 + 「はじめる」タップ → localStorage に保存 → メイン画面遷移
+4. 以降の Workers 呼出で `X-App-Password: {password}` ヘッダー付与
+5. 401 応答 → `localStorage.removeItem('password')` → パスワード画面に戻す、エラー文言表示
+
+**セッション寿命**: localStorage に永続。ユーザが明示的にクリアしない限り再入力不要。
+
+### 3.7 エラーハンドリング総覧
+
+| エラー種別 | 検出 | 対応 |
+|---|---|---|
+| GPS 権限拒否 | onError code 1 | 2.3(a) 画面、watchPosition 停止 |
+| GPS 測位失敗（一時的） | onError code 2, 3 | 画面維持、次の成功を待つ |
+| N03 GeoJSON fetch 失敗 | fetch reject / 4xx/5xx | ステップ3（GSI）へフォールバック |
+| GSI 逆ジオコーダ失敗 | fetch reject / 4xx/5xx | 2.3(b) 未確定状態、60 秒後に再試行 |
+| Workers 401 | fetch 401 | パスワード画面へ戻す（3.6） |
+| Workers 502/503/5xx | fetch reject / 5xx | 3 回指数バックオフ、失敗時 2.3(c) |
+| localStorage 容量超過 | try/catch QuotaExceededError | PoC: 古い軌跡を半数トリム（Phase 2 以降で精緻化） |
+
+---
+
+## 4. データ仕様
+
+### 4.1 N03 GeoJSON
+
+- **配置**: `/municipalities/{N03_007}.geojson`
+- **形式**: GeoJSON FeatureCollection
+- **Feature プロパティ**:
+   - `N03_001`: 都道府県名（例: `"神奈川県"`）
+   - `N03_004`: 市区町村名（例: `"相模原市緑区"`）
+   - `N03_007`: 全国地方公共団体コード（例: `"14151"`）
+- **Geometry**: Polygon または MultiPolygon（飛び地対応）
+- **簡略化**: shapely `simplify(0.0005, preserve_topology=True)`
+- **座標精度**: 小数点以下 5 桁
+
+### 4.2 adjacency.json
+
+- **配置**: `/adjacency.json`（ルート直下）
+- **形式**:
+  ```json
+  {
+    "14150": ["14151", "14152", "14401"],
+    "14151": ["14150", "14152", "14100", "14212"]
+  }
+  ```
+- **キー**: 市町村コード
+- **値**: 隣接する市町村コードの配列
+- **生成方法**: Python (geopandas + shapely) で `geometry.touches(other) or geometry.intersects(other.buffer(0.00001))` を全ペアに対して計算
+
+### 4.3 localStorage データ構造
+
+```json
+{
+  "password": "a3f9b12c8e4d6710ff293a4bc1e8d5d2",
+  "visited": {
+    "14151": {
+      "name": "相模原市緑区",
+      "prefecture": "神奈川県",
+      "firstVisit": "2026-04-22T10:00:00.000Z",
+      "descriptions": {
+        "spring": "緑区は津久井湖や相模湖を抱く、山と水の町です。...",
+        "summer": null,
+        "autumn": null,
+        "winter": null
+      }
+    }
+  },
+  "track": [
+    { "lat": 35.5681, "lon": 139.3712, "ts": 1745000000000 }
+  ],
+  "currentMuniCd": "14151"
+}
+```
+
+**キー説明**:
+- `password`: 認証パスワード（平文保存、端末紛失時のリスクは許容）
+- `visited`: 訪問済み市町村情報とLLM解説キャッシュ
+- `track`: 通過軌跡、上限 5000 点（PoC では超過時ノーオペ、Phase 2 でトリム）
+- `currentMuniCd`: 現在の市町村コード（起動時復元用）
+
+### 4.4 地理院タイル
+
+- **URL テンプレート**: `https://cyberjapandata.gsi.go.jp/xyz/pale/{z}/{x}/{y}.png`
+- **ライセンス**: PDL1.0、申請不要、出典明示必須
+- **最大ズーム**: 18
+
+### 4.5 国土地理院逆ジオコーダ
+
+- **URL**: `https://mreversegeocoder.gsi.go.jp/reverse-geocoder/LonLatToAddress?lat={lat}&lon={lon}`
+- **レスポンス形式**:
+  ```json
+  {
+    "results": {
+      "muniCd": "14151",
+      "lv01Nm": "中央区"
+    }
+  }
+  ```
+- **CORS**: 対応済み（ブラウザから直接 fetch 可）
+- **注意**: 実験的サービス。PoC のフォールバック利用は許容、商用本番では別手段を検討
+
+---
+
+## 5. API 仕様（Cloudflare Workers）
+
+### 5.1 エンドポイント
+
+唯一のエンドポイント: `POST /api/describe`
+
+### 5.2 認証
+
+- ヘッダー `X-App-Password: {password}` 必須
+- 未付与または `APP_PASSWORD` と不一致 → 401 Unauthorized
+- Workers 側は `crypto.subtle.timingSafeEqual` 相当の定数時間比較を実装
+
+### 5.3 リクエスト
+
+```http
+POST /api/describe
+Content-Type: application/json
+X-App-Password: a3f9b12c8e4d6710ff293a4bc1e8d5d2
+
+{
+  "prefecture": "神奈川県",
+  "municipality": "相模原市緑区",
+  "season": "spring"
+}
+```
+
+必須フィールド: `prefecture` / `municipality` / `season`  
+`season` の値: `"spring" | "summer" | "autumn" | "winter"`
+
+### 5.4 レスポンス
+
+**成功** (200):
+```json
+{ "description": "緑区は津久井湖や相模湖を抱く、山と水の町です。..." }
+```
+
+**認証失敗** (401):
+```json
+{ "error": "unauthorized" }
+```
+
+**リクエスト不正** (400):
+```json
+{ "error": "bad_request", "detail": "missing required field: season" }
+```
+
+**上流エラー** (502):
+```json
+{ "error": "upstream_error", "detail": "Anthropic API error: ..." }
+```
+
+### 5.5 CORS
+
+- `Access-Control-Allow-Origin`: Workers Secret `ALLOWED_ORIGIN`（Cloudflare Pages ドメイン）
+- `Access-Control-Allow-Methods`: `POST, OPTIONS`
+- `Access-Control-Allow-Headers`: `Content-Type, X-App-Password`
+- OPTIONS プリフライト対応必須
+
+### 5.6 Workers Secrets
+
+| キー | 内容 |
+|---|---|
+| `APP_PASSWORD` | 32 文字 hex パスワード |
+| `ANTHROPIC_API_KEY` | Anthropic API キー |
+| `ALLOWED_ORIGIN` | `https://trip-road.pages.dev` 等、許可するオリジン |
+
+---
+
+## 6. LLM プロンプトテンプレート
+
+### 6.1 System prompt（Workers 側に直書き）
+
+```
+あなたは日本の旅行ガイドです。指定された都道府県・市区町村・季節から、旅人が通過する際に楽しめる3〜4文の観光ガイド文を書いてください。
+
+以下のルールを守ってください：
+- 文体は「です・ます調」の現代的な観光ガイド
+- 120〜180字の範囲に収める
+- 歴史・地形・名物・特産品は具体的に書いてよい
+- 祭りやイベントの具体的な日付・回数・年号は書かない（代わりに「例年◯月頃」と表現する）
+- その土地の「春/夏/秋/冬」の季節感（旬の食材・景色・花・魚など）に必ず触れる
+- プレーンテキストのみ、マークダウン記法や箇条書きは使わない
+- 確信が持てない情報は無理に書かない（情報量が減っても正確さを優先）
+- 旅情を損なう過度な商業表現（「おすすめ！」など）は避ける
+```
+
+### 6.2 User prompt（Workers で組み立て）
+
+```
+都道府県: {prefecture}
+市区町村: {municipality}
+季節: {season_ja}
+```
+
+`season_ja` は: spring→春、summer→夏、autumn→秋、winter→冬 と変換。
+
+### 6.3 Anthropic Messages API 呼出パラメータ
+
+```json
+{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 400,
+  "system": "[6.1 のテキスト]",
+  "messages": [
+    { "role": "user", "content": "[6.2 のテキスト]" }
+  ]
+}
+```
+
+### 6.4 出力例
+
+**入力**: 神奈川県 / 相模原市緑区 / 春  
+**期待出力**:
+> 緑区は津久井湖や相模湖を抱く、山と水の町です。春は桜が湖畔を彩り、例年4月には山間部の棚田にも花が咲き始めます。津久井やまゆりラインの沿道では、地場の柚子やこんにゃくが並ぶ直売所が旅人を迎えてくれます。
+
+**避けたい出力**（ハルシネーション例）:
+> 相模原市緑区では第45回さくら祭りが4月5日から開催されます。
+
+具体的な回数・日付・年号を書かせないのがプロンプトの狙い。
+
+---
+
+## 7. PWA / iOS ホーム画面追加仕様
+
+### 7.1 index.html の `<head>` メタタグ
+
+```html
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
+<meta name="theme-color" content="#0f0f10">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="trip-road">
+<link rel="apple-touch-icon" sizes="180x180" href="/icon-180.png">
+<link rel="manifest" href="/manifest.json">
+<title>trip-road</title>
+```
+
+### 7.2 manifest.json
+
+```json
+{
+  "name": "trip-road",
+  "short_name": "trip-road",
+  "description": "GPSで土地のたよりを届ける、旅のお供",
+  "icons": [
+    { "src": "/icon-180.png", "sizes": "180x180", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f0f10",
+  "theme_color": "#0f0f10",
+  "orientation": "portrait"
+}
+```
+
+### 7.3 アイコン仕様（PoC 仮置き）
+
+- ファイル: `/icon-180.png`（180×180、PNG）
+- デザイン: 背景 `#0f0f10`、中央に `TR`（`#5dcaa5`、太字サンセリフ、90px）
+- 角丸不要（iOS が自動適用）
+
+---
+
+## 8. テスト戦略
+
+### 8.1 単体テスト
+
+対象：
+- `getSeason(date)` の境界条件（2/28, 3/1, 5/31, 6/1, 8/31, 9/1, 11/30, 12/1）
+- キャッシュキー生成: `${code}_${season}`
+- 市町村切替判定
+- localStorage 保存/復元
+
+**ツール**: Node.js + 標準 `assert`（ビルド不要で速い）  
+**配置**: `tests/unit/*.test.js`  
+**実行**: `node --test tests/unit/`
+
+### 8.2 結合テスト（Workers）
+
+`wrangler dev` 起動下で curl シナリオを実行：
+
+```bash
+# 成功
+curl -X POST http://localhost:8787/api/describe \
+  -H "Content-Type: application/json" \
+  -H "X-App-Password: {test_password}" \
+  -d '{"prefecture":"神奈川県","municipality":"相模原市緑区","season":"spring"}'
+
+# 認証失敗
+curl -X POST http://localhost:8787/api/describe \
+  -H "X-App-Password: wrong" \
+  -d '{}'
+
+# 必須欠落
+curl -X POST http://localhost:8787/api/describe \
+  -H "X-App-Password: {test_password}" \
+  -d '{"prefecture":"神奈川県"}'
+```
+
+### 8.3 実機テスト（Phase 4 完了判定）
+
+チェックリスト：
+- [ ] iPhone Safari でサイトを開くとパスワード画面
+- [ ] 正しいパスワードでメイン画面遷移
+- [ ] GPS 許可ダイアログが出る
+- [ ] 許可後、現在地マーカー表示
+- [ ] 移動で速度が km/h 更新
+- [ ] 市町村境界越えで土地のたよりが更新
+- [ ] 再訪でキャッシュから即表示
+- [ ] オフライン時、GPS 更新は継続、他は壊れない
+- [ ] 「ホーム画面に追加」でアイコン出現
+- [ ] アイコンから開くとスタンドアロンモード起動
+- [ ] 制覇カウントが累積
+- [ ] 再起動してもデータ維持
+
+### 8.4 GPS モック（開発時）
+
+- Chrome DevTools の Sensors パネルで座標を手動設定
+- または `navigator.geolocation.watchPosition` をラップしたテストスクリプトで録画 GPX を再生
+
+---
+
+## 9. デプロイ仕様
+
+### 9.1 Cloudflare Pages（フロント + データ）
+
+- プロジェクト名: `trip-road`
+- ソース: ローカル `public/` ディレクトリ
+- デプロイコマンド: `wrangler pages deploy public/ --project-name=trip-road`
+- ドメイン: `https://trip-road.pages.dev`（独自ドメインなし）
+
+### 9.2 Cloudflare Workers（API）
+
+- プロジェクト名: `trip-road-api`
+- ソース: `workers/src/index.js`
+- 設定: `workers/wrangler.toml`
+- デプロイ: `cd workers && wrangler deploy`
+- Secrets: `wrangler secret put APP_PASSWORD`, `ANTHROPIC_API_KEY`, `ALLOWED_ORIGIN`
+
+### 9.3 ロールバック
+
+- Pages: `wrangler pages deployment list` で旧版を `--rollback`
+- Workers: 旧 script 内容で `wrangler deploy` 再実行
+
+---
+
+## 10. 次のステップ
+
+1. この spec.md を実装の原典として合意（ユーザレビュー）
+2. writing-plans スキルを起動し、Phase 0 〜 4 の詳細タスクを step-by-step で作成
+3. Phase 0（準備: Anthropic アカウント・API キー・パスワード生成）から着手


### PR DESCRIPTION
## 概要

memo.txt を出発点としたブレインストーミングで確定した設計を、デザインカンプと組み合わせて実装可能な詳細仕様書として整備しました。合わせて、iPhone Safari で実機表示可能なプレビュー用ラッパー HTML を追加します。

## 追加内容

### 1. デザインプレビュー（`docs/design/preview.html`）

`trip_road_main_screen_mockup.html` は Claude Artifact フラグメント形式のためブラウザ単独では表示できませんでした。DOCTYPE・viewport meta・CSS 変数定義でラップしたスタンドアロン HTML を追加し、iPhone Safari で「ホーム画面に追加」を含む表示検証が可能にしました。

- 外枠用 CSS 変数（`--color-background-secondary` 等）をラッパーで定義
- `apple-mobile-web-app-capable` でスタンドアロンモード事前検証
- このマージ後に GitHub Pages を有効化して実機確認URLを用意予定

### 2. 機能仕様書（`docs/spec.md`、611 行追加）

plan.md とデザインカンプで確定した設計を実装詳細レベルまで落とし込みました。

- **2章**: 画面仕様（モックアップ準拠 + 未デザイン状態のテキスト定義）
- **3章**: 機能仕様詳細（GPS / 判定フロー / LLM 呼出 / エラー処理）
- **4章**: データ仕様（N03 / adjacency.json / localStorage / GSI 逆ジオコーダ）
- **5章**: Workers API 仕様（エンドポイント / 認証 / CORS / Secrets）
- **6章**: LLM プロンプトテンプレート（system / user + 出力例）
- **7章**: PWA メタタグ・manifest.json
- **8章**: テスト戦略（単体 / 結合 / 実機 / GPS モック）
- **9章**: デプロイ仕様

優先順位: `mockup.html` > `spec.md` > `plan.md` > `memo.txt` と明記しました。

## レビュー観点

- [ ] `preview.html` の見た目が想定通りか（PCブラウザ or ローカル HTTPサーバで確認可）
- [ ] `spec.md` の設計がブレスト結果と整合しているか
- [ ] 未デザイン状態（パスワード・エラー・初期・ローディング）のテキスト定義が妥当か

## マージ後の作業

1. GitHub Pages を main ブランチから有効化（iPhone 実機確認用URL作成）
2. writing-plans スキルで Phase 0〜4 の実装計画を作成
3. Phase 0（準備）から着手