### PR TITLE
fix(ui): 再生成完了後の loading-text 残留修正を再投入

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -896,6 +896,26 @@ Plan D Stage 1 で導入した `📤` ボタン（`exportTelemetryAsJson` + `dow
 
 これは「次の出力例を見せて真似させる」teacher forcing とは違い、「前回ダメだった部分を引用して避けるべきパターンを教える」negative example の渡し方。Few-shot とも別の文脈情報。Sonnet judge が出した deductions（「桜が美しい（汎用）」）を Haiku generator にそのまま渡すという、judge → generator の情報フィードバックループの構築。
 
+## 4.14 再生成完了後の loading-text 残留バグ（2026-05-03）
+
+### 4.14.1 症状
+
+Judge NG → 再生成のフローで本文は差し替わるが、本文の上に出ていた「✏️ より良い表現に書き直しています…」のテキストだけが画面に残り続けていた。再生成成功時のみ目立つが、原因は再生成に固有ではない。
+
+### 4.14.2 原因
+
+`public/assets/ui.js` の `setDescription` が `#description-skeleton`（プレースホルダのバー）は `hidden` 化していた一方で、別要素である `#description-loading-text`（フェーズ別文言を表示する要素、`index.html:79`）には何も触れていなかった。両要素は `index.html` 上で並んでおり、初期状態では両方 `hidden`、ローディング開始時に skeleton と loading-text の両方が `hidden` 解除される。本文確定時に skeleton だけ閉じても loading-text は開いたまま、というアンバランスが原因。
+
+`setDescriptionFailed` は両方を hidden にしていたので失敗系では発症しない。`setDescription` と `clearDescription` の更新漏れ。
+
+### 4.14.3 対策
+
+`setDescription` / `clearDescription` の中で `#description-loading-text` も `hidden` にする 1 行を追加。`document.getElementById` の戻りが null のケースに備えて `if (txt)` で防御。テストは `test/ui_dom.test.js` に新設し、依存追加を避けるため `globalThis.document` を最小スタブして classList と textContent の遷移だけ検証する。
+
+### 4.14.4 教訓
+
+ローディング表示を「skeleton」と「文言テキスト」の 2 要素に分割した時点で、本文確定の出口側でも両方を閉じる責務が発生する。今回はその対応漏れ。表示状態の対称性（開く側で触る要素は閉じる側でも触る）を意識する。
+
 ---
 
 ## 5. 参考資料

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -221,6 +221,13 @@
 - [x] 相模原市南区で軸 1 の事実検証が機能（「茶畑」「古淵駅中心」「江戸期の河岸」を Wikipedia 不在として正しく減点）
 - [ ] **翌日実走（人間タスク）**: iPhone 実機で `https://trip-road.tetutetu214.com/` を開いて GPS 移動、市町村切替時の段階表示・⚙️ デバッグオーバーレイ動作確認、翌日 `bash docs/analysis/fetch_entries.sh` で Plan E 集計が出ることを確認
 
+### 6.8 再生成完了後の loading-text 残留バグ修正（完了 2026-05-03）
+
+- [x] `public/assets/ui.js` の `setDescription` / `clearDescription` で `#description-loading-text` を `hidden` 化
+- [x] `test/ui_dom.test.js` を新設し、依存追加なしで `globalThis.document` をスタブして DOM 副作用を検証（4 ケース）
+- [x] `docs/knowledge.md` 4.14 章にバグの原因と教訓を記録
+- [ ] **本番反映 + 実機確認（人間タスク）**: Pages 反映後に iPhone で「再生成→本文表示」の遷移で loading-text が消えること、通常生成でも残留しないことを確認
+
 ---
 
 ## Plan F: Plan E 完成度向上 + 観測強化

--- a/public/assets/ui.js
+++ b/public/assets/ui.js
@@ -39,6 +39,10 @@ export function setDescription(text) {
   const body = $('description');
   const skel = $('description-skeleton');
   skel.classList.add('hidden');
+  // 再生成完了時に「より良い表現に書き直しています…」が残らないよう、
+  // ローディング文言要素も明示的に隠す（skeleton と loading-text は別要素）
+  const txt = $('description-loading-text');
+  if (txt) txt.classList.add('hidden');
   body.classList.remove('muted');
   body.textContent = text;
   body.style.opacity = 0;
@@ -91,6 +95,8 @@ export function phaseToText(phase) {
 export function clearDescription() {
   $('description').textContent = '';
   $('description-skeleton').classList.add('hidden');
+  const txt = $('description-loading-text');
+  if (txt) txt.classList.add('hidden');
 }
 
 export function setGpsActive(active) {

--- a/test/ui_dom.test.js
+++ b/test/ui_dom.test.js
@@ -1,0 +1,104 @@
+/**
+ * setDescription / clearDescription の DOM 副作用テスト。
+ *
+ * vitest の environment は node 固定（vitest.config.js）なので、
+ * 依存追加を避けるために document を最小限スタブする。
+ * 検証対象は classList と textContent のみで、レイアウト計算には踏み込まない。
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    setDescription,
+    setDescriptionFailed,
+    clearDescription,
+    setDescriptionLoadingPhase,
+} from '../public/assets/ui.js';
+
+function makeEl() {
+    const classes = new Set();
+    return {
+        classList: {
+            add: (c) => classes.add(c),
+            remove: (c) => classes.delete(c),
+            contains: (c) => classes.has(c),
+        },
+        style: {},
+        textContent: '',
+    };
+}
+
+let savedDocument;
+let savedRAF;
+let els;
+
+beforeEach(() => {
+    savedDocument = globalThis.document;
+    savedRAF = globalThis.requestAnimationFrame;
+    els = {
+        description: makeEl(),
+        'description-skeleton': makeEl(),
+        'description-loading-text': makeEl(),
+    };
+    // 初期状態: skeleton と loading-text は hidden（index.html の初期状態と同じ）
+    els['description-skeleton'].classList.add('hidden');
+    els['description-loading-text'].classList.add('hidden');
+    globalThis.document = {
+        getElementById: (id) => els[id] ?? null,
+    };
+    globalThis.requestAnimationFrame = (fn) => fn();
+});
+
+afterEach(() => {
+    globalThis.document = savedDocument;
+    globalThis.requestAnimationFrame = savedRAF;
+});
+
+describe('setDescription', () => {
+    it('本文を反映し、skeleton と loading-text を hidden にする（再生成完了時の文言残留防止）', () => {
+        // 再生成中の状態を作る: loading-text に文言が出ている
+        setDescriptionLoadingPhase('regenerating');
+        expect(els['description-loading-text'].classList.contains('hidden')).toBe(false);
+        expect(els['description-loading-text'].textContent).toBe('✏️ より良い表現に書き直しています…');
+
+        setDescription('土地のたより本文');
+
+        expect(els.description.textContent).toBe('土地のたより本文');
+        expect(els['description-skeleton'].classList.contains('hidden')).toBe(true);
+        // 「より良い表現に書き直しています…」が画面に残らないこと
+        expect(els['description-loading-text'].classList.contains('hidden')).toBe(true);
+    });
+
+    it('muted クラスは外す', () => {
+        els.description.classList.add('muted');
+        setDescription('本文');
+        expect(els.description.classList.contains('muted')).toBe(false);
+    });
+});
+
+describe('clearDescription', () => {
+    it('本文と loading-text を共にクリアする', () => {
+        els.description.textContent = '前回の表示';
+        setDescriptionLoadingPhase('judging');
+        expect(els['description-loading-text'].classList.contains('hidden')).toBe(false);
+
+        clearDescription();
+
+        expect(els.description.textContent).toBe('');
+        expect(els['description-skeleton'].classList.contains('hidden')).toBe(true);
+        expect(els['description-loading-text'].classList.contains('hidden')).toBe(true);
+    });
+});
+
+describe('setDescriptionFailed', () => {
+    it('失敗時もエラー表示と共に loading-text を hidden にする', () => {
+        setDescriptionLoadingPhase('generating');
+        expect(els['description-loading-text'].classList.contains('hidden')).toBe(false);
+
+        setDescriptionFailed();
+
+        expect(els.description.textContent).toBe('解説を取得できませんでした');
+        expect(els.description.classList.contains('muted')).toBe(true);
+        expect(els['description-skeleton'].classList.contains('hidden')).toBe(true);
+        expect(els['description-loading-text'].classList.contains('hidden')).toBe(true);
+    });
+});


### PR DESCRIPTION
## 概要

PR #31 のマージ後、別件の「土地のたより本文が表示されない」事象を疑って一時的に revert（PR #31 → revert commit `2e06588`）していたが、切り分けの結果、本事象の原因は本 PR の表示修正とは無関係と判明したため、当初の修正をそのまま再投入する。

## 切り分け結果

- バックエンド（Workers / Anthropic）は健康（curl で HTTP 200、CORS 正常、tail にリクエスト 0 件）
- 既存ブラウザの localStorage に `currentMuniCd = 自宅の市町村` が保存済み
- trip-road は「市町村が切り替わった瞬間のみ API を呼ぶ」設計のため、自宅で起動しても切替が起きず API 呼出されない
- かつ Plan E 以降、judge 合格(true)の解説しかキャッシュしないので、合格していない場合は表示も空のまま
- シークレットウィンドウで再ログインしたら（localStorage 空 → currentMuniCd=null → 自宅 ≠ null で切替成立）、解説が出ることを確認

→ revert により本番に「再生成後に文言が残るバグ」だけが残った状態。原本を再投入する。

## 変更内容

PR #31 と完全同一（差分は同じ commit）。
- `public/assets/ui.js`: `setDescription` / `clearDescription` で `#description-loading-text` を `hidden` 化
- `test/ui_dom.test.js`: 依存追加なしの DOM スタブで 4 ケース検証
- `docs/knowledge.md` 4.14 章 / `docs/todo.md` 6.8 節: 記録

## テスト

- `npx vitest run`（フロント）: 41 / 41 passed
- `cd workers && npx vitest run`: 97 / 97 passed（変更なしだが念のため）

## 別タスク

「自宅起動時に解説が出ない」問題は別途 todo に追加予定（仕様判断を伴うため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)