### PR TITLE
feat(workers): 決定論 Faithfulness Judge をシャドウ並列実行で導入 (#52)

### DIFF
--- a/public/assets/api.js
+++ b/public/assets/api.js
@@ -82,9 +82,16 @@ export async function fetchDescription(password, req, opts = {}) {
             regenerated: data.regenerated ?? false,
             fallback_to_extract: data.fallback_to_extract ?? false,
             wikipedia_extract_length: data.wikipedia_extract_length ?? null,
+            wikidata_attributes_length: data.wikidata_attributes_length ?? null,
             judge_error: data.judge_error ?? null,
             generator_model: data.generator_model ?? null,
             judge_model: data.judge_model ?? null,
+            // Issue #52: シャドウ運用フィールド
+            deterministic_score: data.deterministic_score ?? null,
+            deterministic_passed: data.deterministic_passed ?? null,
+            deterministic_out_of_kb_terms: Array.isArray(data.deterministic_out_of_kb_terms)
+              ? data.deterministic_out_of_kb_terms
+              : [],
           };
         }
         lastError = { ok: false, status: res.status, error: 'empty_description' };

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -333,9 +333,13 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
               regenerated: result.regenerated,
               fallback_to_extract: result.fallback_to_extract,
               wikipedia_extract_length: result.wikipedia_extract_length,
+              wikidata_attributes_length: result.wikidata_attributes_length,
               judge_error: result.judge_error,
               generator_model: result.generator_model,
               judge_model: result.judge_model,
+              deterministic_score: result.deterministic_score,
+              deterministic_passed: result.deterministic_passed,
+              deterministic_out_of_kb_terms: result.deterministic_out_of_kb_terms,
             }));
             currentDisplayStartMs = Date.now();
             updateTelemetry(currentTraceId, { ts_displayed: currentDisplayStartMs });

--- a/public/assets/telemetry.js
+++ b/public/assets/telemetry.js
@@ -64,6 +64,14 @@ export function buildTelemetryEntry(args) {
     generator_model: args.generator_model ?? null,
     judge_model: args.judge_model ?? null,
 
+    // Issue #38: Wikidata 構造化属性の取得結果サイズ
+    wikidata_attributes_length: args.wikidata_attributes_length ?? null,
+
+    // Issue #52 シャドウ運用: 決定論 Judge の並行結果（記録専用、本決定は judge_passed）
+    deterministic_score: args.deterministic_score ?? null,
+    deterministic_passed: args.deterministic_passed ?? null,
+    deterministic_out_of_kb_terms: args.deterministic_out_of_kb_terms ?? null,
+
     // 暗黙シグナル
     ts_displayed: null,
     ts_left: null,

--- a/workers/src/describe_flow.js
+++ b/workers/src/describe_flow.js
@@ -49,6 +49,23 @@ export function formatOutOfKbTermsForFeedback(terms) {
 }
 
 /**
+ * Issue #52 シャドウ運用: judge 結果から決定論 Judge のシャドウ結果を取り出す。
+ * テレメトリ用に Nova と並行して記録する形に揃える。
+ *
+ * @param {object|null} judge - judgeAll の戻り値（null は judge を呼ばなかったケース）
+ * @returns {{deterministic_score: number|null, deterministic_out_of_kb_terms: string[],
+ *             deterministic_passed: boolean|null}}
+ */
+function shadowFields(judge) {
+  const d = judge?.deterministic;
+  return {
+    deterministic_score: d?.score ?? null,
+    deterministic_out_of_kb_terms: d?.out_of_kb_terms ?? [],
+    deterministic_passed: d?.passed ?? null,
+  };
+}
+
+/**
  * Wikipedia 抜粋を 60〜180 字に収めて返す（純粋関数、フォールバック転載用）。
  *
  * - 抜粋が FALLBACK_MIN_LENGTH 未満なら、そのまま返す
@@ -157,6 +174,7 @@ export async function generateAndJudge(parsed, env, deps = {}) {
       judge_error: null,
       generator_model: GENERATOR_MODEL,
       judge_model: JUDGE_MODEL,
+      ...shadowFields(null),
     };
   }
 
@@ -192,6 +210,7 @@ export async function generateAndJudge(parsed, env, deps = {}) {
       judge_error: null,
       generator_model: GENERATOR_MODEL,
       judge_model: JUDGE_MODEL,
+      ...shadowFields(judge1),
     };
   }
 
@@ -210,6 +229,7 @@ export async function generateAndJudge(parsed, env, deps = {}) {
       judge_error: judge1.error,
       generator_model: GENERATOR_MODEL,
       judge_model: JUDGE_MODEL,
+      ...shadowFields(judge1),
     };
   }
 
@@ -237,6 +257,7 @@ export async function generateAndJudge(parsed, env, deps = {}) {
       judge_error: null,
       generator_model: GENERATOR_MODEL,
       judge_model: JUDGE_MODEL,
+      ...shadowFields(judge1),
     };
   }
 
@@ -265,6 +286,7 @@ export async function generateAndJudge(parsed, env, deps = {}) {
       judge_error: null,
       generator_model: GENERATOR_MODEL,
       judge_model: JUDGE_MODEL,
+      ...shadowFields(judge2),
     };
   }
 
@@ -282,5 +304,6 @@ export async function generateAndJudge(parsed, env, deps = {}) {
     judge_error: judge2.error,
     generator_model: GENERATOR_MODEL,
     judge_model: JUDGE_MODEL,
+    ...shadowFields(judge2),
   };
 }

--- a/workers/src/deterministic_judge.js
+++ b/workers/src/deterministic_judge.js
@@ -1,0 +1,139 @@
+/**
+ * Faithfulness 軽量決定論 Judge（Issue #52 / Plan I Phase 2-2）
+ *
+ * 生成文から「漢字 2 文字以上」「カタカナ 3 文字以上」「数字 2 文字以上」を抽出し、
+ * Wikipedia 抜粋 + Wikidata 構造化属性に substring として含まれるかを機械的に判定する。
+ * LLM judge と違い、同じ入力に対して必ず同じ結果を返す。
+ *
+ * 形態素解析（kuromoji.js）を採用しない理由:
+ *   - 辞書 19 MB が Workers の bundle size 制限（1 MB）に収まらない
+ *   - CDN から runtime fetch する案は cold start で数秒のレイテンシ
+ *   - 正規表現ベースの「固有名詞っぽい列」抽出で大半のハルシネーション検出はカバー可能
+ *
+ * シャドウ運用設計:
+ *   Nova Pro Judge と並列に走らせ、結果をテレメトリに記録して一致率を観測する。
+ *   Nova → 決定論への切り替えは観測後の独立タスク。
+ *
+ * すべて純粋関数。副作用なし、外部 fetch なし。
+ */
+
+// 漢字 2 文字以上（CJK 統合漢字 + 々）
+const KANJI_RE = /[一-鿿々]{2,}/g;
+// カタカナ 3 文字以上（長音符号 ー を含む）
+const KATAKANA_RE = /[゠-ヿー]{3,}/g;
+// 数字 2 文字以上（半角アラビア数字）
+const DIGIT_RE = /\d{2,}/g;
+
+// PASS_THRESHOLD と整合する合格しきい値（judge.js の PASS_THRESHOLD=4 と一致）
+export const DETERMINISTIC_PASS_THRESHOLD = 4;
+
+/**
+ * 文字列から「固有名詞っぽい列」を抽出する。重複削除済みの配列を返す。
+ *
+ * 抽出対象:
+ *   - 漢字 2 文字以上: "千代田", "東京都", "皇居" 等
+ *   - カタカナ 3 文字以上: "バンクーバー", "ローゼンハイム" 等（"区" のような単漢字は対象外）
+ *   - 数字 2 文字以上: "1947", "14", "180" 等
+ *
+ * ひらがなは助詞・接続詞・活用語尾が多く意味の薄い一致を生むため対象外。
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function extractProperNounLikeStrings(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+  const tokens = new Set();
+  for (const re of [KANJI_RE, KATAKANA_RE, DIGIT_RE]) {
+    for (const m of text.matchAll(re)) {
+      tokens.add(m[0]);
+    }
+  }
+  return Array.from(tokens);
+}
+
+/**
+ * 生成文から抽出した候補のうち、kbText に substring として含まれないものを返す。
+ *
+ * substring 照合の意義:
+ *   - "1947" が抜粋本文 "...1947 年に..." に含まれる → OK
+ *   - "皇居" が抜粋 "...皇居外苑..." に含まれる → OK
+ *   - "秋葉原" が抜粋に出てこなければ → out_of_kb_terms 入り
+ *
+ * @param {string} description - 採点対象の生成文
+ * @param {string} kbText - Wikipedia 抜粋 + Wikidata 属性ブロックを結合したテキスト
+ * @returns {string[]}
+ */
+export function findOutOfKbTerms(description, kbText) {
+  const candidates = extractProperNounLikeStrings(description);
+  const kb = typeof kbText === 'string' ? kbText : '';
+  return candidates.filter((token) => !kb.includes(token));
+}
+
+/**
+ * out_of_kb_terms の件数からスコアを決定する。
+ *
+ * Nova Pro Judge の 5 段階採点と整合させる:
+ *   - 0 件 → 5（完全合格）
+ *   - 1 件 → 4（許容範囲、PASS_THRESHOLD=4 の最下限）
+ *   - 2 件 → 3（不合格、再生成対象）
+ *   - 3 件 → 2
+ *   - 4 件以上 → 1（直接矛盾相当）
+ *
+ * @param {number} count
+ * @returns {number}
+ */
+export function scoreFromOutOfKbCount(count) {
+  if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) {
+    return 1;
+  }
+  if (count === 0) return 5;
+  if (count === 1) return 4;
+  if (count === 2) return 3;
+  if (count === 3) return 2;
+  return 1;
+}
+
+/**
+ * Faithfulness 決定論 Judge のメイン関数。
+ *
+ * params.wikidataPromptBlock が空文字 / 未指定なら Wikipedia 単独で評価
+ * （Wikidata 取得スキップ時のフォールバック）。
+ *
+ * @param {object} params
+ * @param {string} params.description - 採点対象の生成文
+ * @param {string} params.wikipediaExtract - cleanExtract 適用済の Wikipedia 抜粋
+ * @param {string} [params.wikidataPromptBlock] - formatWikidataForPrompt の出力
+ * @returns {{
+ *   score: number,
+ *   passed: boolean,
+ *   out_of_kb_terms: string[],
+ *   notes: string,
+ * }}
+ */
+export function deterministicJudge({
+  description,
+  wikipediaExtract,
+  wikidataPromptBlock,
+}) {
+  if (typeof description !== 'string' || description.length === 0) {
+    return {
+      score: 1,
+      passed: false,
+      out_of_kb_terms: [],
+      notes: 'empty description',
+    };
+  }
+  const wp = typeof wikipediaExtract === 'string' ? wikipediaExtract : '';
+  const wd = typeof wikidataPromptBlock === 'string' ? wikidataPromptBlock : '';
+  // Wikipedia 抜粋と Wikidata 属性を改行で連結（substring 照合には影響しない）
+  const kbText = wp + '\n' + wd;
+
+  const outOfKb = findOutOfKbTerms(description, kbText);
+  const score = scoreFromOutOfKbCount(outOfKb.length);
+  return {
+    score,
+    passed: score >= DETERMINISTIC_PASS_THRESHOLD,
+    out_of_kb_terms: outOfKb,
+    notes: `deterministic: ${outOfKb.length} out-of-kb terms`,
+  };
+}

--- a/workers/src/index.js
+++ b/workers/src/index.js
@@ -113,6 +113,10 @@ export default {
           judge_error: flow.judge_error,
           generator_model: flow.generator_model,
           judge_model: flow.judge_model,
+          // Issue #52 シャドウ運用: 決定論 Judge の並行結果（記録専用、本決定は judge_passed）
+          deterministic_score: flow.deterministic_score ?? null,
+          deterministic_passed: flow.deterministic_passed ?? null,
+          deterministic_out_of_kb_terms: flow.deterministic_out_of_kb_terms ?? [],
         },
         200,
         allowedOrigin,

--- a/workers/src/judge.js
+++ b/workers/src/judge.js
@@ -15,6 +15,7 @@
 
 import { buildFaithfulnessPrompt } from './judge_prompts.js';
 import { callConverse, NOVA_MODEL_ID } from './nova.js';
+import { deterministicJudge } from './deterministic_judge.js';
 
 // ---- 定数 ----
 
@@ -159,6 +160,7 @@ export async function judgeAll({
       score: null,
       out_of_kb_terms: [],
       error: null,
+      deterministic: null,
     };
   }
 
@@ -171,8 +173,19 @@ export async function judgeAll({
       score: null,
       out_of_kb_terms: [],
       error: 'wikipedia_extract_missing',
+      deterministic: null,
     };
   }
+
+  // Issue #52 シャドウ運用: Nova Judge と並列に決定論 Judge を実行する。
+  // 結果は記録専用、本決定は依然として Nova Judge 側。
+  const deterministicShadow = (() => {
+    try {
+      return deterministicJudge({ description, wikipediaExtract, wikidataPromptBlock });
+    } catch (_err) {
+      return null;
+    }
+  })();
 
   try {
     const result = await judgeRunner(
@@ -187,6 +200,7 @@ export async function judgeAll({
         score: null,
         out_of_kb_terms: result.out_of_kb_terms ?? [],
         error: result.notes ?? null,
+        deterministic: deterministicShadow,
       };
     }
 
@@ -196,6 +210,7 @@ export async function judgeAll({
       score: result.score,
       out_of_kb_terms: result.out_of_kb_terms,
       error: null,
+      deterministic: deterministicShadow,
     };
   } catch (err) {
     return {
@@ -204,6 +219,7 @@ export async function judgeAll({
       score: null,
       out_of_kb_terms: [],
       error: err?.message ?? String(err),
+      deterministic: deterministicShadow,
     };
   }
 }

--- a/workers/test/deterministic_judge.test.js
+++ b/workers/test/deterministic_judge.test.js
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DETERMINISTIC_PASS_THRESHOLD,
+  extractProperNounLikeStrings,
+  findOutOfKbTerms,
+  scoreFromOutOfKbCount,
+  deterministicJudge,
+} from '../src/deterministic_judge.js';
+
+describe('定数', () => {
+  it('合格しきい値は 4（judge.js の PASS_THRESHOLD と整合）', () => {
+    expect(DETERMINISTIC_PASS_THRESHOLD).toBe(4);
+  });
+});
+
+describe('extractProperNounLikeStrings', () => {
+  it('漢字 2 文字以上を抽出', () => {
+    const out = extractProperNounLikeStrings('千代田区は東京都の特別区です');
+    expect(out).toContain('千代田区');
+    expect(out).toContain('東京都');
+    expect(out).toContain('特別区');
+  });
+
+  it('単漢字「区」「都」「市」のような 1 文字は除外', () => {
+    const out = extractProperNounLikeStrings('区 都 市');
+    expect(out).not.toContain('区');
+    expect(out).not.toContain('都');
+    expect(out).not.toContain('市');
+  });
+
+  it('カタカナ 3 文字以上を抽出（長音符号含む）', () => {
+    const out = extractProperNounLikeStrings('バンクーバーと姉妹都市');
+    expect(out).toContain('バンクーバー');
+  });
+
+  it('カタカナ 2 文字以下は除外（短すぎる）', () => {
+    const out = extractProperNounLikeStrings('バー');
+    expect(out).not.toContain('バー');
+  });
+
+  it('数字 2 文字以上を抽出', () => {
+    const out = extractProperNounLikeStrings('1947 年と 180 度');
+    expect(out).toContain('1947');
+    expect(out).toContain('180');
+  });
+
+  it('1 桁数字は除外', () => {
+    const out = extractProperNounLikeStrings('1 と 2 と 3');
+    expect(out).not.toContain('1');
+  });
+
+  it('ひらがなは抽出しない', () => {
+    const out = extractProperNounLikeStrings('あいうえお かきくけこ');
+    expect(out).toEqual([]);
+  });
+
+  it('重複を排除する', () => {
+    const out = extractProperNounLikeStrings('東京都の東京都の東京都');
+    const count = out.filter((t) => t === '東京都').length;
+    expect(count).toBe(1);
+  });
+
+  it('空文字 / null は空配列', () => {
+    expect(extractProperNounLikeStrings('')).toEqual([]);
+    expect(extractProperNounLikeStrings(null)).toEqual([]);
+    expect(extractProperNounLikeStrings(undefined)).toEqual([]);
+  });
+
+  it('複合的な実例（千代田区の解説）', () => {
+    const text = '千代田区は東京都の特別区で、1947 年に旧麹町区と旧神田区が合併。皇居を中心とする。';
+    const out = extractProperNounLikeStrings(text);
+    expect(out).toEqual(
+      expect.arrayContaining(['千代田区', '東京都', '特別区', '1947', '旧麹町区', '旧神田区', '皇居'])
+    );
+  });
+});
+
+describe('findOutOfKbTerms', () => {
+  const KB = '千代田区は東京都の特別区である。1947 年に旧麹町区と旧神田区が合併。皇居や霞が関を擁する。';
+
+  it('抜粋の語彙だけで構成された生成文は空配列', () => {
+    // 「中心」「誕生」のような一般 2 文字漢字は避ける（既知の弱点を回避する書き方）
+    const desc = '千代田区は東京都の特別区です。1947 年に旧麹町区と旧神田区が合併し皇居を擁します。';
+    expect(findOutOfKbTerms(desc, KB)).toEqual([]);
+  });
+
+  it('抜粋外の固有名詞を検出', () => {
+    const desc = '千代田区は東京都の特別区で、秋葉原や新宿があります。';
+    const out = findOutOfKbTerms(desc, KB);
+    expect(out).toContain('秋葉原');
+    expect(out).toContain('新宿');
+  });
+
+  it('抜粋に含まれる substring としての一致を許容', () => {
+    // KB には "旧麹町区" がある → "麹町" も substring として含まれる
+    const desc = '麹町';
+    const out = findOutOfKbTerms(desc, KB);
+    expect(out).not.toContain('麹町');
+  });
+
+  it('kbText が空でも候補が出れば全部 out_of_kb_terms 入り', () => {
+    const out = findOutOfKbTerms('千代田区は東京都にある', '');
+    expect(out).toContain('千代田区');
+    expect(out).toContain('東京都');
+  });
+
+  // ---- ライト案の既知の限界（シャドウ運用で観測対象） ----
+
+  it('既知の限界 1: 一般 2 文字漢字（中心・誕生）は false positive で out_of_kb 入り', () => {
+    const desc = '皇居を中心として 1947 年に誕生した千代田区です。';
+    const out = findOutOfKbTerms(desc, KB);
+    expect(out).toContain('中心'); // KB に「中心」という substring がない
+    expect(out).toContain('誕生'); // KB に「誕生」という substring がない
+  });
+
+  it('既知の限界 2: 複合語問題（抜粋「市制が施行」と生成文「市制施行」がマッチしない）', () => {
+    // Nova Pro Judge も同じ誤検知パターンを示すので、ライト案でも改善はしないが、
+    // 別の理由（substring 完全一致）で同じ結果になることをテストで明示
+    const kb = '東松山市は埼玉県の中部に位置する。1954 年に市制が施行された。';
+    const desc = '1954 年に市制施行した東松山市です。';
+    const out = findOutOfKbTerms(desc, kb);
+    // "市制施行" は連続 4 文字漢字として抽出され、KB の "市制が施行"（間に「が」）に
+    // substring 一致しない。これは形態素解析を入れないと解消しない既知の制約
+    expect(out).toContain('市制施行');
+  });
+});
+
+describe('scoreFromOutOfKbCount', () => {
+  it('0 件 → 5（完全合格）', () => {
+    expect(scoreFromOutOfKbCount(0)).toBe(5);
+  });
+  it('1 件 → 4（許容、合格圏内）', () => {
+    expect(scoreFromOutOfKbCount(1)).toBe(4);
+  });
+  it('2 件 → 3（不合格）', () => {
+    expect(scoreFromOutOfKbCount(2)).toBe(3);
+  });
+  it('3 件 → 2', () => {
+    expect(scoreFromOutOfKbCount(3)).toBe(2);
+  });
+  it('4 件以上 → 1', () => {
+    expect(scoreFromOutOfKbCount(4)).toBe(1);
+    expect(scoreFromOutOfKbCount(10)).toBe(1);
+  });
+  it('不正値は 1 にフォールバック', () => {
+    expect(scoreFromOutOfKbCount(-1)).toBe(1);
+    expect(scoreFromOutOfKbCount(NaN)).toBe(1);
+    expect(scoreFromOutOfKbCount('a')).toBe(1);
+  });
+});
+
+describe('deterministicJudge', () => {
+  const WIKIPEDIA =
+    '千代田区は東京都の特別区である。1947 年に旧麹町区と旧神田区が合併。皇居を擁する。';
+  const WIKIDATA =
+    '種別: 日本の特別区\n名前の由来: 千代田\n構成地区: 西神田, 麹町, 丸の内, 永田町, 霞が関';
+
+  it('Wikipedia + Wikidata に裏付けられた生成文 → score 5 / passed', () => {
+    // 生成文は抜粋の語彙だけで構成する（「有名」「誕生」のような一般 2 文字漢字は避ける）
+    const desc =
+      '千代田区は東京都の特別区です。1947 年に旧麹町区と旧神田区が合併し、皇居を擁します。';
+    const result = deterministicJudge({
+      description: desc,
+      wikipediaExtract: WIKIPEDIA,
+      wikidataPromptBlock: WIKIDATA,
+    });
+    expect(result.score).toBe(5);
+    expect(result.passed).toBe(true);
+    expect(result.out_of_kb_terms).toEqual([]);
+  });
+
+  it('Wikidata で補強される地名（西神田・丸の内）は素材内扱い', () => {
+    const desc = '千代田区は東京都の特別区で、西神田や丸の内を含みます。';
+    const result = deterministicJudge({
+      description: desc,
+      wikipediaExtract: WIKIPEDIA,
+      wikidataPromptBlock: WIKIDATA,
+    });
+    expect(result.out_of_kb_terms).toEqual([]);
+    expect(result.score).toBe(5);
+  });
+
+  it('Wikipedia / Wikidata どちらにもない地名 → out_of_kb_terms 入り', () => {
+    const desc = '千代田区は東京都の特別区で、秋葉原や新宿があります。';
+    const result = deterministicJudge({
+      description: desc,
+      wikipediaExtract: WIKIPEDIA,
+      wikidataPromptBlock: WIKIDATA,
+    });
+    expect(result.out_of_kb_terms).toContain('秋葉原');
+    expect(result.out_of_kb_terms).toContain('新宿');
+    expect(result.score).toBeLessThanOrEqual(3);
+    expect(result.passed).toBe(false);
+  });
+
+  it('Wikidata 未指定（Wikipedia 単独）でも動作', () => {
+    const desc = '千代田区は東京都の特別区です。';
+    const result = deterministicJudge({
+      description: desc,
+      wikipediaExtract: WIKIPEDIA,
+    });
+    expect(result.score).toBe(5);
+    expect(result.passed).toBe(true);
+  });
+
+  it('空の description は score=1 / passed=false', () => {
+    const result = deterministicJudge({
+      description: '',
+      wikipediaExtract: WIKIPEDIA,
+    });
+    expect(result.score).toBe(1);
+    expect(result.passed).toBe(false);
+  });
+
+  it('既知の弱点: 一般 2 文字漢字（有名・誕生 等）は false positive で out_of_kb_terms 入りする', () => {
+    // 形態素解析を使わないライト案の宿命。シャドウ運用で誤検知率を観測した上で、
+    // 必要なら STOPWORDS リストの追加で段階的に対処する（Phase 2-2 の出口判断）。
+    const desc = '千代田区は東京都の特別区で、秋葉原が有名です。';
+    const result = deterministicJudge({
+      description: desc,
+      wikipediaExtract: WIKIPEDIA,
+      wikidataPromptBlock: WIKIDATA,
+    });
+    expect(result.out_of_kb_terms).toContain('秋葉原'); // true positive
+    expect(result.out_of_kb_terms).toContain('有名');    // false positive（既知の弱点）
+  });
+});


### PR DESCRIPTION
## Summary

- Plan I Phase 2-2: Nova Pro Judge と並列に「正規表現ベースの決定論 Faithfulness Judge」を走らせるシャドウ運用を有効化
- ユーザ体験は完全不変（Generator・Nova Judge の本決定ロジックは変更なし、Bedrock 訲金も不変）
- テレメトリに `deterministic_score` / `deterministic_passed` / `deterministic_out_of_kb_terms` が並行記録され、後で Nova との一致率・誤検知率を集計できる

Issue: #52

## 設計判断のポイント

### 形態素解析器 (kuromoji.js) を採用しなかった理由

辞書 19 MB が Workers の bundle size 制限 1 MB を超え、CDN 経由 fetch でも cold start +数秒のコスト増になる。正規表現ベースのライト案で大半のハルシネーション検出はカバーでき、誤検知率はシャドウ運用で実測してから対処判断する段階的アプローチを採用。

### ライト案の仕組み

```js
// 生成文から「漢字 2 文字以上」「カタカナ 3 文字以上」「数字 2 文字以上」を抽出
const candidates = extractProperNounLikeStrings(description);

// Wikipedia 抜粋 + Wikidata 属性に substring として含まれるかチェック
const outOfKb = candidates.filter(t => !kbText.includes(t));

// 件数からスコア決定 (0→5, 1→4, 2→3, 3→2, 4+→1)
const score = scoreFromOutOfKbCount(outOfKb.length);
```

決定論的（同じ入力に必ず同じ出力）、bundle size 影響ゼロ、Nova Judge 呼出 1 件あたり 1ms 未満の追加。

### 既知の弱点（テストで明示、シャドウ運用で実測対象）

- **一般 2 文字漢字の false positive**: 「有名」「中心」「誕生」のような語彙が抜粋にないと検出される。形態素解析の品詞情報がないので避けられない
- **複合語問題**: 生成文「市制施行」が抜粋「市制が施行」と substring 一致しない。Nova Judge も同種の誤検知をする問題

両方とも `workers/test/deterministic_judge.test.js` で「既知の限界」テストとして明示。シャドウ運用で実測した上で STOPWORDS リスト追加 / 形態素解析 / kuromoji 統合のいずれに進むかを後日判断。

## テスト結果

- vitest 192 件 全 PASS（新規 deterministic_judge.test.js 29 件 + 既存 163 件）
- 既存テストへのリグレッションなし

## 観測項目（本番反映後）

- **Nova 判定 vs 決定論判定の一致率**: 90% 以上なら kuromoji への進化は不要、85% 未満なら STOPWORDS or kuromoji 検討
- **決定論 Judge の false positive 件数**: 一般 2 文字漢字パターンを集計
- **複合語問題の発生頻度**: 抜粋にある語が連続化して検出漏れする頻度

## ロールバック手段

- Workers: Cloudflare ダッシュボードで前 Version (#38 反映後の e738c315...) に 1 クリック Rollback
- Pages: 同様にダッシュボードで前デプロイへ Rollback
- 並行運用なのでロールバック影響はゼロ

## Test plan

- [x] vitest 192 件 全 PASS
- [x] 既知の弱点（一般 2 文字漢字 false positive、複合語問題）をテストで明示
- [x] シャドウ運用なので Generator 経路は不変、本番ユーザ体験は変わらない
- [ ] マージ後 `bash workers/deploy_production.sh` + `bash deploy_frontend.sh` で本番反映
- [ ] curl sweep で Nova と決定論の差分を 10 件分集計、knowledge.md 4.29 章に記録