### PR TITLE
fix(frontend): 軌跡を「今日の分だけ」地図に描画する

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1790,6 +1790,50 @@ Phase 2-2 の本実装（シャドウ運用基盤）は完了。次の方向性�
 
 ---
 
+## 4.30 軌跡描画の「今日縛り」と踏破履歴の保存先方針（2026-05-23）
+
+### 4.30.1 背景
+
+長期間の使用で localStorage `track` 配列に過去日のポイントが積み上がり、地図全面が緑線で覆われて当日の移動が判別不能になった。
+
+### 4.30.2 構造の確認
+
+- `public/assets/storage.js` の `track: [{lat, lon, ts}]` は **フロント localStorage のみ**に存在。`appendTrack` で append され、永続クリア手段がなかった。
+- `public/assets/app.js:114` で起動時に `state.track` 全件を `setTrack` していたため、過去全部の点が緑ポリラインに乗っていた。
+- **S3 テレメトリには位置点列は含まれない**。`telemetry.js:buildTelemetryEntry` のスキーマには `muni_code`/`description`/Judge 指標/暗黙シグナルしか入っていない。緯度経度は Workers にも送っていない。
+- したがって track を temp で消しても **Judge 改善ループに必要なデータは欠損しない**。観測駆動の反復は影響を受けない。
+
+### 4.30.3 採用した方針
+
+**「localStorage は全件温存・描画だけ今日に絞る」**。
+
+- `track_filter.js` を新設し、`isSameLocalDay`（ローカル暦日比較）と `filterTodayPoints`（純粋関数）を切り出した。純粋関数にしたことで Vitest 単体で 8 件カバーできる。
+- 起動時: `filterTodayPoints(state.track, Date.now())` の結果だけを `setTrack` に渡す。`state.track` 自体には触らない。
+- 走行中の日跨ぎ: モジュールスコープ `lastTrackTs` を持ち、`addTrackPoint` 直前で `isSameLocalDay(lastTrackTs, now)` が false なら `clearTrack` してから新規開始。`appendTrack` は変わらず呼び続けるので localStorage 側は追記される。
+- これにより「日付が変わった瞬間に地図がリセット、データは温存」が両立する。
+
+### 4.30.4 不採用案と理由
+
+- **起動時に track = [] にクリア**: 実装は最小だが、Safari のリロード（電池切れ復帰など旅の途中で起きやすい）で当日の軌跡まで消える。観測駆動の前提（旅の途中で再起動はあり得る）に合わない。
+- **直近 N 件で打ち切り**: ポイント数は GPS 取得頻度に依存し、てつてつの利用シーン（電車旅）では1日 1〜2 万点も普通にあり得るので、N の妥当値が決められない。日付軸で切るほうが UX の説明可能性が高い。
+- **手動クリアボタン**: 押し忘れて今と同じ状態に戻る。自動の保険として将来追加してもよいが、まずは時間軸で自動化したほうが UX が安定する。
+
+### 4.30.5 踏破履歴の保存先（今後の検討メモ）
+
+てつてつから「踏破市町村画面を作りたい、DynamoDB がよさそう」との発言。本セッションでは設計しないが、観点だけ残す。
+
+- **S3 JSON 上書き保存案の弱点**: 1 リクエスト = 全件再読込。「踏破済 100 件」が「踏破済 101 件」になるたびに全件 GET する設計はスケールしない。CloudFront/Workers Cache を挟んでも書込直後の整合性が不安定。
+- **DynamoDB が向く理由**: PK/SK で「日付別の踏破リスト」「市町村別の訪問履歴」両方の問い合わせが効率的。容量課金で月コスト数百円規模（てつてつ 1 ユーザー）で済む。Workers から SigV4 で `PutItem`/`Query` を叩く前例は本プロジェクトの S3 PUT と同じ aws4fetch ライブラリで再利用可能。
+- **設計時の論点**:
+   - PK 設計: `tetutetu#YYYY-MM-DD` か `tetutetu` + SK `visit#YYYY-MM-DD#<muni_code>` か。日付クエリと市町村クエリの頻度で決める
+   - 既存テレメトリとの関係: telemetry は「LLM 評価の生データ」、踏破履歴は「ユーザー向け集計」。テーブル分離が素直
+   - 初回ロード時のリストア: localStorage `visited` を真実とせず、DynamoDB から取得した結果を localStorage にミラーする読み戻し設計が必要
+   - 移行: 既存 localStorage の `visited` を一度だけ DynamoDB に書き戻す one-shot 移行スクリプト
+
+実装着手前に `docs/plan.md` で plan → spec → 理解度テスト → 実装の順を踏む。todo.md にタスクを追加済。
+
+---
+
 ## 5. 参考資料
 
 ### 5.1 使用データ・API

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -518,6 +518,29 @@ UI 側で「立体的な地理把握」を補強。Generator/Judge/テレメト�
 - [x] 本番反映: `bash deploy_frontend.sh`（HTTP 200 確認、2026-05-21）
 - [ ] **観測（人間タスク）**: iPhone 実機で `https://trip-road.tetutetu214.com/` を開いて (1) ⛰️ トグルで陰影起伏図 ON/OFF が動くか、(2) 標高バッジに数値が出るか、(3) CORS NG なら別 Issue で Workers 経由に格上げ
 
+## Issue: 軌跡の「今日の分だけ表示」化（2026-05-23）
+
+過去日の軌跡が緑線として地図全面に残り、当日の移動内容が判別できなくなった事象への対応。
+localStorage の `track` は触らずに描画側だけ「今日の ts」に絞ることで、将来の踏破履歴ビュー（DynamoDB 計画）でも履歴を使えるよう温存する。
+
+- [x] `public/assets/track_filter.js` 新設: `isSameLocalDay` / `filterTodayPoints`（純粋関数）
+- [x] `public/assets/map.js` に `clearTrack`（ポリラインだけ空にする）追加
+- [x] `public/assets/app.js` 起動時に `filterTodayPoints` で絞り込み、`addTrackPoint` 直前に日跨ぎ判定して `clearTrack`
+- [x] Vitest テスト追加（`test/track_filter.test.js` 8 件、合計 79 件 pass）
+- [ ] PR レビュー → マージ → `bash deploy_frontend.sh` で本番反映
+- [ ] **観測（人間タスク）**: iPhone 実機で「翌日起動したら地図が空に戻り、当日の動きだけ緑線になる」ことを確認
+
+## 踏破市町村画面 + DynamoDB 構想（要設計）
+
+「行った市町村を日付別に見られる」履歴ビューを作るための土台。位置点列を S3 にロギングしていない（テレメトリは `muni_code` 粒度のみ）ため、踏破履歴をクラウド側に持ちたいなら別データストアが必要。
+
+- [ ] `docs/plan.md` / `docs/spec.md` に「踏破履歴ビュー」セクションを起こす
+- [ ] DynamoDB vs S3 JSON の比較ノートを `docs/knowledge.md` に追記（読み出しレイテンシ、書込頻度、コスト）
+- [ ] スキーマ草案: PK=`userId`, SK=`visit#YYYY-MM-DD#<muni_code>`（日付＋市町村で 1 レコード）
+- [ ] Workers から DynamoDB に書ける IAM/SigV4 経路の設計
+- [ ] 理解度テスト（DynamoDB の課金モデル、PK/SK 設計、Workers からの SigV4 呼出）
+- [ ] 実装はこの設計が固まってから別ブランチで着手
+
 ## Issue #48: 陰影起伏図トグルを 3 段階（OFF/弱/強）に拡張（2026-05-21）
 
 Issue #46 の opacity 0.3 は控えめという実機フィードバックを受け、循環トグルで濃さを切替えられるように拡張。

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -23,7 +23,8 @@ import {
 } from './storage.js';
 import { fetchDescription, sendTelemetryBatch } from './api.js';
 import { identifyMunicipality, prefetchNeighbors } from './muni.js';
-import { initMap, updateCurrentLocation, addTrackPoint, setTrack, setHillshadeLevel as applyHillshadeLayer } from './map.js';
+import { initMap, updateCurrentLocation, addTrackPoint, setTrack, clearTrack, setHillshadeLevel as applyHillshadeLayer } from './map.js';
+import { filterTodayPoints, isSameLocalDay } from './track_filter.js';
 import { startWatching } from './geo.js';
 import { fetchElevation, createElevationUpdater } from './elevation.js';
 import { generateTraceId, buildTelemetryEntry, shouldSample } from './telemetry.js';
@@ -42,6 +43,9 @@ import {
 let currentMuniCd = null;
 let isFirstFix = true;
 let elevationUpdater = null;
+// 軌跡ポリラインに最後に乗せた点のタイムスタンプ（ms）。
+// 起動時の復元と、日跨ぎ時のポリライン自動リセット判定に使う。
+let lastTrackTs = null;
 
 // Plan E (6.5b): デバッグオーバーレイの状態管理
 // currentJudgeData は最後に表示した解説の判定情報を保持し、
@@ -109,9 +113,13 @@ async function enterMainApp(password) {
   initMap('map');
   setVisitedCount(getVisitedCount());
 
-  // 既存軌跡を復元
+  // 既存軌跡を復元（今日の ts のものだけ描画。過去日分は localStorage に温存）
   const state = loadState();
-  if (state.track.length > 0) setTrack(state.track);
+  const todayPoints = filterTodayPoints(state.track, Date.now());
+  if (todayPoints.length > 0) {
+    setTrack(todayPoints);
+    lastTrackTs = todayPoints[todayPoints.length - 1].ts;
+  }
 
   // 既存の現在地情報を表示（キャッシュ済要約があれば）
   if (currentMuniCd && state.visited[currentMuniCd]) {
@@ -224,8 +232,17 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
   const wasFirstFix = isFirstFix;
   updateCurrentLocation(lat, lon, isFirstFix);
   isFirstFix = false;
+
+  // 日跨ぎが起きていたらポリラインを一旦クリアして「今日」を新規開始する。
+  // localStorage 側の track は appendTrack で従来どおり追記され続けるので、
+  // 過去日の軌跡データはそのまま温存される（将来の踏破履歴ビュー用）。
+  const nowMs = Date.now();
+  if (lastTrackTs !== null && !isSameLocalDay(lastTrackTs, nowMs)) {
+    clearTrack();
+  }
   addTrackPoint(lat, lon);
   appendTrack(lat, lon);
+  lastTrackTs = nowMs;
 
   // 市町村判定
   const muni = await identifyMunicipality(lat, lon, currentMuniCd);

--- a/public/assets/map.js
+++ b/public/assets/map.js
@@ -97,6 +97,15 @@ export function setTrack(points) {
 }
 
 /**
+ * 地図上の軌跡ポリラインを空にする。
+ * localStorage 側の track は変更しない（履歴データは温存）。
+ */
+export function clearTrack() {
+  if (!trackLine) return;
+  trackLine.setLatLngs([]);
+}
+
+/**
  * 陰影起伏図レイヤーのレベル切替（Issue #48: off / weak / strong）。
  * off ならレイヤーを map から外し、weak/strong なら opacity を切替えて add。
  */

--- a/public/assets/track_filter.js
+++ b/public/assets/track_filter.js
@@ -1,0 +1,37 @@
+/**
+ * 軌跡ポイント列を「今日の分」だけに絞る純粋関数群。
+ *
+ * 「今日」はローカルタイムでの暦日（年/月/日が一致するか）で判定する。
+ * UTC ではなく端末ローカルにするのは、日本国内のユーザーが
+ * 「日付が変わったら新しい軌跡」と感覚的に揃えるため。
+ */
+
+/**
+ * 2 つの UNIX ms タイムスタンプが同一ローカル暦日に属するかを判定する。
+ *
+ * @param {number} tsA
+ * @param {number} tsB
+ * @returns {boolean}
+ */
+export function isSameLocalDay(tsA, tsB) {
+  const a = new Date(tsA);
+  const b = new Date(tsB);
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+/**
+ * 軌跡ポイント列のうち、ローカル暦日が `nowMs` と同じものだけを返す。
+ * ts を持たない古いエントリは「日付不明＝今日ではない」として除外する。
+ *
+ * @param {Array<{lat:number, lon:number, ts?:number}>} points
+ * @param {number} nowMs
+ * @returns {Array<{lat:number, lon:number, ts:number}>}
+ */
+export function filterTodayPoints(points, nowMs) {
+  if (!Array.isArray(points)) return [];
+  return points.filter((p) => typeof p?.ts === 'number' && isSameLocalDay(p.ts, nowMs));
+}

--- a/test/track_filter.test.js
+++ b/test/track_filter.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { isSameLocalDay, filterTodayPoints } from '../public/assets/track_filter.js';
+
+describe('isSameLocalDay', () => {
+  it('同じ日のミリ秒タイムスタンプは true', () => {
+    const a = new Date(2026, 4, 23, 9, 0, 0).getTime();
+    const b = new Date(2026, 4, 23, 18, 30, 0).getTime();
+    expect(isSameLocalDay(a, b)).toBe(true);
+  });
+
+  it('日付が異なれば false（前日との比較）', () => {
+    const today = new Date(2026, 4, 23, 0, 30, 0).getTime();
+    const yesterday = new Date(2026, 4, 22, 23, 59, 59).getTime();
+    expect(isSameLocalDay(today, yesterday)).toBe(false);
+  });
+
+  it('1 年違い同日付でも false', () => {
+    const a = new Date(2026, 4, 23, 12, 0, 0).getTime();
+    const b = new Date(2025, 4, 23, 12, 0, 0).getTime();
+    expect(isSameLocalDay(a, b)).toBe(false);
+  });
+});
+
+describe('filterTodayPoints', () => {
+  const now = new Date(2026, 4, 23, 12, 0, 0).getTime();
+
+  it('今日のポイントだけを返す（順序を保つ）', () => {
+    const yesterday = new Date(2026, 4, 22, 8, 0, 0).getTime();
+    const todayMorning = new Date(2026, 4, 23, 7, 0, 0).getTime();
+    const todayNoon = new Date(2026, 4, 23, 12, 0, 0).getTime();
+
+    const points = [
+      { lat: 1, lon: 1, ts: yesterday },
+      { lat: 2, lon: 2, ts: todayMorning },
+      { lat: 3, lon: 3, ts: todayNoon },
+    ];
+
+    expect(filterTodayPoints(points, now)).toEqual([
+      { lat: 2, lon: 2, ts: todayMorning },
+      { lat: 3, lon: 3, ts: todayNoon },
+    ]);
+  });
+
+  it('全部過去日なら空配列', () => {
+    const yesterday = new Date(2026, 4, 22, 8, 0, 0).getTime();
+    const points = [{ lat: 1, lon: 1, ts: yesterday }];
+    expect(filterTodayPoints(points, now)).toEqual([]);
+  });
+
+  it('ts を持たない古いエントリは除外', () => {
+    const todayNoon = new Date(2026, 4, 23, 12, 0, 0).getTime();
+    const points = [
+      { lat: 1, lon: 1 },
+      { lat: 2, lon: 2, ts: todayNoon },
+    ];
+    expect(filterTodayPoints(points, now)).toEqual([
+      { lat: 2, lon: 2, ts: todayNoon },
+    ]);
+  });
+
+  it('points が配列でなければ空配列を返す', () => {
+    expect(filterTodayPoints(undefined, now)).toEqual([]);
+    expect(filterTodayPoints(null, now)).toEqual([]);
+  });
+
+  it('日跨ぎ境界: 23:59:59 と翌 00:00:00 は別日扱い', () => {
+    const lateNight = new Date(2026, 4, 22, 23, 59, 59, 999).getTime();
+    const justAfterMidnight = new Date(2026, 4, 23, 0, 0, 0, 0).getTime();
+    const points = [
+      { lat: 1, lon: 1, ts: lateNight },
+      { lat: 2, lon: 2, ts: justAfterMidnight },
+    ];
+    expect(filterTodayPoints(points, now)).toEqual([
+      { lat: 2, lon: 2, ts: justAfterMidnight },
+    ]);
+  });
+});


### PR DESCRIPTION
## 概要

長期使用で過去日の軌跡（緑ポリライン）が地図全面を覆い、当日の移動が判別できなくなる事象を解消する。localStorage 側の `track` は触らず、**描画レイヤでローカル暦日フィルタを掛ける**方針。

## 背景

- localStorage `track: [{lat, lon, ts}]` は `appendTrack` で延々追記されるだけで、永続的なクリア手段が無かった
- 起動時に `setTrack(state.track)` で全件をポリラインに乗せていたため、過去全日の点がそのまま緑線として描画されていた
- S3 テレメトリには位置点列は元から含まれず（`telemetry.js:buildTelemetryEntry` の schema を参照）、Judge 改善ループには影響しない

## 変更点

- `public/assets/track_filter.js` を新設し、`isSameLocalDay` / `filterTodayPoints` を純粋関数として切り出し
- `public/assets/map.js` に `clearTrack` を追加（ポリラインだけ空にする）
- `public/assets/app.js`
   - 起動時に `filterTodayPoints(state.track, Date.now())` で絞り込んでから `setTrack`
   - 走行中は `addTrackPoint` 直前に `isSameLocalDay(lastTrackTs, now)` を判定して、日跨ぎなら `clearTrack` してから再開
- `appendTrack` 側は不変。localStorage は今後も全履歴を持ち続ける（将来の踏破履歴ビューで活用予定）

## なぜこの方針か

- データを消さない: 「踏破市町村画面 + DynamoDB」を将来作る上で履歴を温存する必要がある（てつてつ判断）
- 自動: 手動クリアボタンは押し忘れで再発するため、時間軸での自動絞り込みを優先
- 不採用案: 起動時 `track=[]` クリアは Safari リロード時に当日分まで失うので却下

## テスト

```
✓ test/track_filter.test.js  (8 tests)
全 79 件 pass（Vitest）
```

## 動作確認（人間タスク）

- [ ] iPhone Safari 実機で `https://trip-road.tetutetu214.com/` を開いて当日の軌跡だけが緑線になることを確認
- [ ] 翌日起動時に地図上の緑線がリセットされること（過去軌跡が見えないこと）を確認
- [ ] 深夜（日付変更）を跨いで利用したとき、新しい日の点だけが残ること（実機で再現困難ならスキップ可）

## 関連メモ

- 詳細な判断記録は `docs/knowledge.md` 4.30 章を参照
- 踏破履歴 + DynamoDB 構想は `docs/todo.md` に別ブロックで切り出し、plan/spec/理解度テストを経て別 PR で着手予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)