### PR TITLE
fix(history): 離島除外で本土のみにフィット（関東・北海道・沖縄の縮尺問題）

### DIFF
--- a/public/assets/history.js
+++ b/public/assets/history.js
@@ -44,6 +44,90 @@ const HISTORY_MAP_ID = 'history-map';
 // 日本全土のおおよその bounds（北海道北端〜沖縄南端を覆う）
 const JAPAN_BOUNDS = [[24, 122], [46, 146]];
 
+/**
+ * 単一 ring の符号付き面積を shoelace 公式で計算（GeoJSON 座標は [lon, lat]）。
+ * 経緯度の度単位での近似面積で、相対比較にのみ使う。
+ */
+export function ringArea(ring) {
+  let area = 0;
+  for (let i = 0, n = ring.length - 1; i < n; i++) {
+    area += ring[i][0] * ring[i + 1][1] - ring[i + 1][0] * ring[i][1];
+  }
+  return Math.abs(area / 2);
+}
+
+/**
+ * GeoJSON Feature の Polygon / MultiPolygon から最大面積の外周 ring を返す。
+ * Leaflet 非依存の純粋関数。離島除外のための「本土 ring」抽出に使う。
+ *
+ * @returns {number[][] | null} ring (= [[lon, lat], ...]), なければ null
+ */
+export function pickMainlandRing(feature) {
+  const geom = feature?.geometry;
+  if (!geom) return null;
+  let rings;
+  if (geom.type === 'Polygon') {
+    rings = [geom.coordinates[0]];
+  } else if (geom.type === 'MultiPolygon') {
+    rings = geom.coordinates.map((poly) => poly[0]);
+  } else {
+    return null;
+  }
+  let bestArea = -1;
+  let bestRing = null;
+  for (const ring of rings) {
+    const area = ringArea(ring);
+    if (area > bestArea) {
+      bestArea = area;
+      bestRing = ring;
+    }
+  }
+  return bestRing;
+}
+
+/**
+ * ring の経緯度範囲を {minLat, maxLat, minLon, maxLon} で返す。純粋関数。
+ */
+export function ringExtent(ring) {
+  if (!ring || ring.length === 0) return null;
+  let minLat = Infinity, maxLat = -Infinity, minLon = Infinity, maxLon = -Infinity;
+  for (const [lon, lat] of ring) {
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+    if (lon < minLon) minLon = lon;
+    if (lon > maxLon) maxLon = lon;
+  }
+  return { minLat, maxLat, minLon, maxLon };
+}
+
+/**
+ * Feature の MultiPolygon / Polygon から「最大面積の polygon」の bounds を返す。
+ *
+ * 離島（小笠原・北方領土・八重山等）を除いた「本土の bounds」を取るための関数。
+ * 単純な L.geoJSON(feature).getBounds() だと離島まで含めてしまい
+ * 関東で小笠原までフィットされて縮尺が無意味になる問題への対策。
+ */
+export function getMainlandBounds(feature) {
+  const ring = pickMainlandRing(feature);
+  if (!ring) return null;
+  const ext = ringExtent(ring);
+  if (!ext) return null;
+  return L.latLngBounds([[ext.minLat, ext.minLon], [ext.maxLat, ext.maxLon]]);
+}
+
+/**
+ * Feature 配列の本土 bounds を合成する（地方レベルで複数都道府県の本土部分を覆う bounds）。
+ */
+export function unionMainlandBounds(features) {
+  let union = null;
+  for (const f of features) {
+    const b = getMainlandBounds(f);
+    if (!b) continue;
+    union = union ? union.extend(b) : b;
+  }
+  return union;
+}
+
 export function setupHistoryScreen() {
   const back = document.querySelector(`#${HISTORY_SCREEN_ID} .history-back`);
   if (back) back.addEventListener('click', handleBack);
@@ -290,10 +374,21 @@ function renderLevel1() {
   }).addTo(historyMap);
 
   try {
-    const bounds = layer.getBounds();
-    if (bounds.isValid()) {
-      historyMap.setMaxBounds(bounds.pad(0.05));
-      historyMap.fitBounds(bounds, { padding: [20, 20] });
+    // 離島を含む getBounds() ではなく、本土だけの bounds を計算してフィット
+    const main = unionMainlandBounds(filtered.features);
+    const full = layer.getBounds();
+    if (main && main.isValid()) {
+      historyMap.fitBounds(main, { padding: [20, 20] });
+      // パン制限は離島も含めた full bounds に少し余裕を持たせて設定
+      // （離島の踏破済が将来描画される場合に備える）
+      if (full && full.isValid()) {
+        historyMap.setMaxBounds(full.pad(0.1));
+      } else {
+        historyMap.setMaxBounds(main.pad(0.3));
+      }
+    } else if (full && full.isValid()) {
+      historyMap.setMaxBounds(full.pad(0.05));
+      historyMap.fitBounds(full, { padding: [20, 20] });
     }
   } catch (_) { /* noop */ }
 }
@@ -323,10 +418,19 @@ async function renderLevel2() {
       interactive: false,
     });
     try {
-      const bounds = prefLayer.getBounds();
-      if (bounds.isValid()) {
-        historyMap.setMaxBounds(bounds.pad(0.05));
-        historyMap.fitBounds(bounds, { padding: [10, 10] });
+      // 離島を含む getBounds() ではなく、本土だけの bounds を採用
+      const main = getMainlandBounds(prefFeature);
+      const full = prefLayer.getBounds();
+      if (main && main.isValid()) {
+        historyMap.fitBounds(main, { padding: [10, 10] });
+        if (full && full.isValid()) {
+          historyMap.setMaxBounds(full.pad(0.1));
+        } else {
+          historyMap.setMaxBounds(main.pad(0.3));
+        }
+      } else if (full && full.isValid()) {
+        historyMap.setMaxBounds(full.pad(0.05));
+        historyMap.fitBounds(full, { padding: [10, 10] });
       }
     } catch (_) { /* noop */ }
     // 県境は最後に add してトップに見せる

--- a/test/history_bounds.test.js
+++ b/test/history_bounds.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Leaflet が global にないと history.js 読込で参照エラーになるので軽くスタブ
+globalThis.L = {
+  latLngBounds: (corners) => ({ _corners: corners, isValid: () => true }),
+};
+
+import { ringArea, pickMainlandRing, ringExtent } from '../public/assets/history.js';
+
+describe('ringArea', () => {
+  it('1x1 の正方形 ring は面積 1', () => {
+    const square = [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]];
+    expect(ringArea(square)).toBeCloseTo(1, 6);
+  });
+
+  it('反時計回りでも絶対値で 1', () => {
+    const ccw = [[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]];
+    expect(ringArea(ccw)).toBeCloseTo(1, 6);
+  });
+
+  it('3x3 正方形は面積 9', () => {
+    const r = [[0, 0], [3, 0], [3, 3], [0, 3], [0, 0]];
+    expect(ringArea(r)).toBeCloseTo(9, 6);
+  });
+});
+
+describe('ringExtent', () => {
+  it('外周の最大・最小経緯度を返す', () => {
+    const ring = [[140, 35], [141, 35], [141, 36], [140, 36], [140, 35]];
+    expect(ringExtent(ring)).toEqual({
+      minLat: 35, maxLat: 36, minLon: 140, maxLon: 141,
+    });
+  });
+
+  it('空配列は null', () => {
+    expect(ringExtent([])).toBeNull();
+  });
+});
+
+describe('pickMainlandRing', () => {
+  it('Polygon は唯一の外周 ring を返す', () => {
+    const feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+      },
+    };
+    expect(pickMainlandRing(feature)).toEqual(
+      [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]],
+    );
+  });
+
+  it('MultiPolygon は最大面積の外周 ring を返す（離島除外）', () => {
+    // 関東のミニチュア: 本土 3x3 + 小笠原相当の小さな 0.5x0.5 離島
+    const mainland = [[139, 35], [142, 35], [142, 38], [139, 38], [139, 35]];
+    const remote = [[142.0, 27.0], [142.5, 27.0], [142.5, 27.5], [142.0, 27.5], [142.0, 27.0]];
+    const feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [[mainland], [remote]],
+      },
+    };
+    // 本土が選ばれるべき
+    const ring = pickMainlandRing(feature);
+    expect(ring).toEqual(mainland);
+  });
+
+  it('順序が逆でも最大面積側が選ばれる', () => {
+    const mainland = [[139, 35], [142, 35], [142, 38], [139, 38], [139, 35]];
+    const remote = [[142.0, 27.0], [142.5, 27.0], [142.5, 27.5], [142.0, 27.5], [142.0, 27.0]];
+    const feature = {
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [[remote], [mainland]],
+      },
+    };
+    expect(pickMainlandRing(feature)).toEqual(mainland);
+  });
+
+  it('未対応 geometry は null', () => {
+    expect(pickMainlandRing({ geometry: { type: 'Point', coordinates: [0, 0] } })).toBeNull();
+    expect(pickMainlandRing(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

PR #56 後の実機観測で発覚した「関東で小笠原まで含まれて縮尺が極端に小さくなり、千葉と茨城の区別がつかない」問題への修正。北海道（北方領土）・沖縄（八重山諸島）でも同じ症状。

## 原因

`L.geoJSON(feature).getBounds()` が MultiPolygon の全 polygon を含めるため、離島まで覆う異常に広い bounds が返り、`fitBounds` で本土が極小スケールに圧縮されていた。

## 修正

各 feature の MultiPolygon の外周 ring を shoelace 公式で面積比較し、**最大面積（=本土）の ring の bounds だけを fitBounds に渡す**。

- `ringArea` / `pickMainlandRing` / `ringExtent` / `getMainlandBounds` / `unionMainlandBounds` を新設
- 純粋関数部分は Leaflet 非依存に切り出して Vitest で検証可能に
- レベル 1（地方）は `unionMainlandBounds(features)` で 7 都県の本土だけを union
- レベル 2（都道府県）は `getMainlandBounds(prefFeature)` で県本土のみ
- `maxBounds` は離島も含めた `full` bounds に pad(0.1) で「踏破時に離島まで見たい場合はスワイプで届く」設計

## テスト

Vitest 9 件追加（全 122 件 pass）:
- ringArea の正方形面積、反時計回り対応
- pickMainlandRing: Polygon / MultiPolygon、coordinates の順序非依存
- 「本土 3x3 + 小笠原相当 0.5x0.5」モデルで本土が選ばれることを確認

## 動作確認

- [ ] 関東を 2 タップで遷移 → 千葉・茨城・東京がしっかり判別できるサイズで表示される
- [ ] 北海道遷移時に北方領土まで含まれず本島中心
- [ ] 沖縄遷移時に八重山まで含まれず本島中心
- [ ] 必要なら手動でスワイプ・ピンチして離島まで見られる

🤖 Generated with [Claude Code](https://claude.com/claude-code)