### PR TITLE
fix(history): 市町村タップで詳細モーダルが出ない問題（県境オーバーレイ廃止）

### DIFF
--- a/public/assets/history.js
+++ b/public/assets/history.js
@@ -411,16 +411,16 @@ async function renderLevel2() {
     total > 0 ? `${Math.round((prefConquests.length / total) * 100)}%` : '',
   );
 
-  // 県境界を点線で薄く表示（市町村レイヤーの上から見えるように後で再 add）
+  // 県境ライン用の overlay は描画しない。
+  // 以前は点線ポリゴンを市町村レイヤーの上に被せていたが、interactive: false が
+  // Leaflet で完全には効かず、市町村タップが吸われて詳細モーダルが開かない
+  // 不具合が起きていた。市町村ポリゴンの輪郭が事実上の県境表示を兼ねる。
   if (prefFeature) {
-    const prefLayer = L.geoJSON(prefFeature, {
-      style: { color: '#9fe1cb', weight: 1.5, fillOpacity: 0, dashArray: '4,4' },
-      interactive: false,
-    });
     try {
-      // 離島を含む getBounds() ではなく、本土だけの bounds を採用
+      // 本土だけの bounds と離島含む full bounds を、map に add せずに算出する
       const main = getMainlandBounds(prefFeature);
-      const full = prefLayer.getBounds();
+      const tmpLayer = L.geoJSON(prefFeature);
+      const full = tmpLayer.getBounds();
       if (main && main.isValid()) {
         historyMap.fitBounds(main, { padding: [10, 10] });
         if (full && full.isValid()) {
@@ -433,8 +433,6 @@ async function renderLevel2() {
         historyMap.fitBounds(full, { padding: [10, 10] });
       }
     } catch (_) { /* noop */ }
-    // 県境は最後に add してトップに見せる
-    prefLayer.addTo(historyMap);
   }
 
   // 県内の全市町村を抽出（conquest_meta が真実）


### PR DESCRIPTION
## 概要

実機フィードバック「緑塗りの踏破済市町村をタップしても詳細モーダル（都市名 + 初回訪問日 + 解説）が出ない」への対応。

## 原因

レベル 2 で県全体の点線オーバーレイ（`prefLayer`）を市町村レイヤーの上に被せていた。`L.geoJSON({interactive: false})` を指定していたが、Leaflet 1.9.4 では各 sub-feature の Path に `interactive: false` が確実には伝播せず、市町村のクリックイベントがオーバーレイで吸われて `renderLevel3` まで届かなかった。

## 修正

県境専用の点線レイヤーを描画しない。背景灰塗りの未踏市町村が県全体を埋めるため、県の形は自然に見える（市町村の輪郭が事実上の県境表示）。

- `prefLayer.addTo(historyMap)` を削除
- bounds 計算用には `L.geoJSON(prefFeature)` を一時生成して `.getBounds()` だけ取得し、map には add しない
- 視認性に問題が出るなら、後日 `pane` を使って下に置き直すなどで再追加可能

## テスト

純粋関数に影響なし、Vitest 全 122 件 pass。

## 動作確認

- [ ] 関東 → 神奈川と進み、緑塗りの綾瀬市など踏破済市町村をタップ
- [ ] 詳細モーダルが開き、`神奈川県 綾瀬市` のような都市名 + 初回訪問日 + 解説が表示される
- [ ] × ボタンでモーダルが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)