### PR TITLE
fix(history): 市町村タップを確実に拾う（未踏→踏破済の add 順固定）

### DIFF
--- a/public/assets/history.js
+++ b/public/assets/history.js
@@ -442,32 +442,51 @@ async function renderLevel2() {
   const conqueredSet = new Set(prefConquests.map(c => c.muni_code));
 
   setLoading(true);
-  // 全市町村ポリゴンを並列 fetch して灰 / 緑で塗り分け
-  await Promise.all(muniCodesInPref.map(async (muniCode) => {
+  // 全市町村ポリゴンを並列 fetch（add は後で順序を制御する）
+  const fetched = await Promise.all(muniCodesInPref.map(async (muniCode) => {
     try {
       const res = await fetch(`${DATA_BASE_URL}/municipalities/${muniCode}.geojson`);
-      if (!res.ok) return;
+      if (!res.ok) return null;
       const geo = await res.json();
-      const isConquered = conqueredSet.has(muniCode);
-      const style = isConquered
-        ? { fillColor: '#5dcaa5', fillOpacity: 0.7, color: '#5dcaa5', weight: 0.6 }
-        : { fillColor: '#2a2a2a', fillOpacity: 0.55, color: '#3a3a3e', weight: 0.4 };
-      L.geoJSON(geo, {
-        style,
-        onEachFeature: (_f, layer) => {
-          if (isConquered) {
-            const conquest = prefConquests.find(c => c.muni_code === muniCode);
-            layer.on('click', () => {
-              currentLevel = 3;
-              renderLevel3(conquest);
-            });
-          }
-        },
-      }).addTo(historyMap);
+      return { muniCode, geo };
     } catch (e) {
       console.warn('[history] muni fetch failed', muniCode, e);
+      return null;
     }
   }));
+
+  // Leaflet の同レイヤー内では「後から add した path が DOM 上で前面」になり、
+  // タップ判定はその前面要素が優先される。並列 fetch で add 順がランダムだと
+  // 未踏（灰）の上に踏破済（緑）が乗ったり逆になったりして、踏破済タップが
+  // 灰塗りに吸われて renderLevel3 が呼ばれない不具合があった。
+  // 確実に「踏破済タップが拾われる」順序にするため、まず未踏を全部 add、
+  // そのあと踏破済を add する 2 パス構造にする。
+
+  // 1) 未踏（灰）を先に add（クリックハンドラなし）
+  for (const item of fetched) {
+    if (!item) continue;
+    if (conqueredSet.has(item.muniCode)) continue;
+    L.geoJSON(item.geo, {
+      style: { fillColor: '#2a2a2a', fillOpacity: 0.55, color: '#3a3a3e', weight: 0.4 },
+    }).addTo(historyMap);
+  }
+
+  // 2) 踏破済（緑）を後に add（クリックハンドラあり、上に乗ってタップを受ける）
+  for (const item of fetched) {
+    if (!item) continue;
+    if (!conqueredSet.has(item.muniCode)) continue;
+    const conquest = prefConquests.find(c => c.muni_code === item.muniCode);
+    L.geoJSON(item.geo, {
+      style: { fillColor: '#5dcaa5', fillOpacity: 0.75, color: '#9fe1cb', weight: 1 },
+      onEachFeature: (_f, layer) => {
+        layer.on('click', () => {
+          currentLevel = 3;
+          renderLevel3(conquest);
+        });
+      },
+    }).addTo(historyMap);
+  }
+
   setLoading(false);
 }
 


### PR DESCRIPTION
## 概要

PR #58 後も「踏破済の緑塗り市町村をタップしても詳細モーダルが出ない」が継続。実機コンソールで DynamoDB 同期は機能している（`[conquests] flushed 1 (written=0, skipped=1)`）ことを確認したため、原因は描画レイヤーの DOM 順問題と判断。

## 原因

`await Promise.all(...).addTo()` で並列に add していたため、未踏（灰）と踏破済（緑）のどちらが先に add されるか不定。後から add された path が DOM 上で前面になり、その path がタップを拾う。未踏が後に来ると踏破済の上を覆ってクリックを吸ってしまう。

## 修正

fetch だけ並列、add は順次に：
1. 未踏ポリゴン（灰、クリックハンドラなし）を全部 add
2. 踏破済ポリゴン（緑、クリックハンドラあり）を後から add

これで踏破済が必ず DOM 上で前面に来てタップを拾う。

副次的に踏破済の見た目を強化:
- `color: '#9fe1cb'` （より明るい縁取り）
- `weight: 1` （太め）
- `fillOpacity: 0.75` （濃く）

タップ可能であることを視覚的に伝える。

## 動作確認

- [ ] 関東 → 神奈川 で踏破済（綾瀬市など）をタップ → 詳細モーダル表示
- [ ] 都市名 + 初回訪問日 + Wikipedia 解説キャッシュが出る
- [ ] × ボタンで閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)