### PR TITLE
fix(history): Canvas renderer 切替 + 画面内デバッグログ

### DIFF
--- a/public/assets/history.css
+++ b/public/assets/history.css
@@ -125,6 +125,28 @@
   padding: 4px 8px;
 }
 
+/* 画面上のデバッグログ表示（コンソール採取が面倒なケース向け） */
+.history-debug-log {
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  z-index: 30;
+  max-width: 80vw;
+  max-height: 35vh;
+  overflow: hidden;
+  padding: 6px 8px;
+  background: rgba(0, 0, 0, 0.75);
+  color: #9fe1cb;
+  border: 1px solid #2e6651;
+  border-radius: 6px;
+  font-family: ui-monospace, 'Menlo', monospace;
+  font-size: 10px;
+  line-height: 1.4;
+  pointer-events: none;
+  white-space: pre-wrap;
+}
+.history-debug-log:empty { display: none; }
+
 /* メイン画面のフッターに置いた 🗺️ ボタン */
 .history-open {
   font-size: 18px;

--- a/public/assets/history.js
+++ b/public/assets/history.js
@@ -175,9 +175,28 @@ function initHistoryMap() {
     attributionControl: false,
     maxBounds: JAPAN_BOUNDS,
     maxBoundsViscosity: 1.0,  // 境界を超えるパンをはね返す
+    // iOS Safari の SVG タップ判定が不安定（path クリックを拾わない）問題への
+    // 対策として Canvas renderer に切り替える。Canvas はクリック判定が安定。
+    preferCanvas: true,
   });
   L.tileLayer(TILE_URL, { maxZoom: 18 }).addTo(historyMap);
   setTimeout(() => historyMap.invalidateSize(), 100);
+}
+
+/**
+ * 画面上にデバッグメッセージを表示する。iOS Safari のコンソールを
+ * 見に行かなくても挙動を観察できるように。本修正が確認できたら削除する。
+ */
+function debugMsg(msg) {
+  console.log('[history]', msg);
+  const el = document.getElementById('history-debug-log');
+  if (!el) return;
+  const time = new Date().toTimeString().slice(0, 8);
+  const line = document.createElement('div');
+  line.textContent = `${time} ${msg}`;
+  el.appendChild(line);
+  // 直近 8 行のみ保持
+  while (el.childElementCount > 8) el.removeChild(el.firstChild);
 }
 
 async function loadHistoryData() {
@@ -406,12 +425,7 @@ async function renderLevel2() {
 
   const prefConquests = conquests.filter(c => c.prefecture_code === currentPrefecture);
   const total = prefTotals[currentPrefecture] ?? 0;
-  console.log('[history] renderLevel2', {
-    prefCode: currentPrefecture,
-    prefName,
-    conqueredCount: prefConquests.length,
-    conqueredCodes: prefConquests.map(c => c.muni_code),
-  });
+  debugMsg(`L2 ${prefName} 踏破=${prefConquests.length}`);
   setStats(
     `${prefName} の踏破: ${prefConquests.length} / ${total}`,
     total > 0 ? `${Math.round((prefConquests.length / total) * 100)}%` : '',
@@ -487,7 +501,7 @@ async function renderLevel2() {
       style: { fillColor: '#5dcaa5', fillOpacity: 0.75, color: '#9fe1cb', weight: 1 },
       onEachFeature: (_f, layer) => {
         layer.on('click', (e) => {
-          console.log('[history] muni clicked', item.muniCode, conquest);
+          debugMsg(`tap ${item.muniCode} ${conquest?.name ?? '?'}`);
           L.DomEvent.stopPropagation(e);
           currentLevel = 3;
           renderLevel3(conquest);
@@ -497,13 +511,12 @@ async function renderLevel2() {
     geoLayer.addTo(historyMap);
     conqueredAdded++;
   }
-  console.log('[history] level2 add finished. conqueredAdded =', conqueredAdded);
+  debugMsg(`L2 緑 add=${conqueredAdded}`);
 
-  // 念のため: map レベルのクリックでも、その位置の踏破済を判定して開く
-  // （個別 path のクリックハンドラがなぜか効かないケースのフォールバック）
+  // 念のため: map レベル click（path クリックが効かない場合の検知）
   historyMap.off('click.historyDebug');
   historyMap.on('click.historyDebug', (e) => {
-    console.log('[history] map clicked at', e.latlng);
+    debugMsg(`map tap ${e.latlng.lat.toFixed(3)},${e.latlng.lng.toFixed(3)}`);
   });
 
   setLoading(false);
@@ -512,10 +525,10 @@ async function renderLevel2() {
 // === レベル 3: 市町村詳細モーダル ===
 
 function renderLevel3(item) {
-  console.log('[history] renderLevel3 called with', item);
+  debugMsg(`L3 ${item?.name ?? '?'}`);
   const detail = document.getElementById('history-detail');
   if (!detail) {
-    console.warn('[history] #history-detail not found');
+    debugMsg('ERR #history-detail なし');
     return;
   }
   const date = new Date(item.first_visit);

--- a/public/index.html
+++ b/public/index.html
@@ -113,6 +113,7 @@
   <div id="history-map" class="history-map"></div>
   <div class="history-loading" style="display:none;">読み込み中…</div>
   <div class="history-error" style="display:none;"></div>
+  <div id="history-debug-log" class="history-debug-log"></div>
   <div id="history-detail" class="history-detail" style="display:none;"></div>
 </section>
 


### PR DESCRIPTION
## 概要

実機タップが効かない問題に対し、SVG → Canvas renderer 切替（iOS Safari の SVG タップ判定不安定問題への根本対策）と、画面内デバッグログ表示（コンソール採取の手間を解消）を入れる。

## 修正

- Leaflet 初期化に `preferCanvas: true` を追加。Path が SVG ではなく Canvas で描画され、iOS Safari のクリック判定が安定する
- 画面右下に `#history-debug-log` を新設。`debugMsg()` で直接表示し Mac Web Inspector を不要に
- 既存の console.log 5 箇所を debugMsg() に置換（コンソールと画面の両方に出る）

## 動作確認手順（てつてつ）

1. iPhone Safari で `https://trip-road.tetutetu214.com/` を**ハードリロード**
2. 🗺️ → 関東 を 2 タップ → 県を 2 タップ
3. 画面左下に小さな緑文字でログが出るので、緑塗り市町村をタップしたとき何が出るか見る

期待される表示の例:
```
18:55:01 L2 神奈川県 踏破=3
18:55:01 L2 緑 add=3
18:55:08 tap 14216 綾瀬市
18:55:08 L3 綾瀬市
```

ここまで出れば詳細モーダルが開いている。
`tap` まで出ない → Canvas でも path タップが届いていない（さらに別対策）
`map tap` が出る → path 以外でタップが拾われている（path 透過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)