### PR TITLE
fix(map): 軌跡の色を緑→マゼンタ (高速道路の緑と地形の灰色と被らない色に)

### DIFF
--- a/public/assets/conquest_rate.js
+++ b/public/assets/conquest_rate.js
@@ -67,7 +67,7 @@ export function rateForMunicipality(muniCode, conquests) {
  *   1-10%    → '#1f3a32' (薄緑)
  *   11-30%   → '#2e6651' (中緑)
  *   31-60%   → '#3f9876' (濃緑)
- *   61-100%  → '#5dcaa5' (最濃、軌跡と同色)
+ *   61-100%  → '#5dcaa5' (最濃、UI のミントグリーン基調)
  *
  * @param {number} rate - 0-1 の踏破率
  * @returns {string} 16 進カラーコード

--- a/public/assets/map.js
+++ b/public/assets/map.js
@@ -34,8 +34,11 @@ export function initMap(containerId) {
   marker = L.marker([35.5, 138], { icon });
   // 初期位置では add しない（GPS 取得後に add）
 
+  // 地理院 pale 地図の「緑色の高速道路」「灰色の地形/等高線」と
+  // 軌跡が被って見にくい問題への対応で、補色のマゼンタに変更（2026-05-26）。
+  // UI ブランド色のミントグリーン (#5dcaa5) は履歴画面・現在地マーカー側に残す。
   trackLine = L.polyline([], {
-    color: '#5dcaa5',
+    color: '#ff4d8c',
     weight: 3,
     opacity: 0.9,
     lineCap: 'round',


### PR DESCRIPTION
## 概要

軌跡ポリラインの色を `#5dcaa5` (ミントグリーン) → `#ff4d8c` (マゼンタ) に変更。

## 背景

実機観察: 地理院 pale 地図の **緑色の高速道路** と **灰色の地形/等高線** に対して、軌跡 (#5dcaa5) が色被りして視認性が悪い。

## 変更

- `public/assets/map.js`: trackLine の color を `#ff4d8c` に
- `public/assets/conquest_rate.js`: 「軌跡と同色」コメントを修正

UI ブランド色のミントグリーン (#5dcaa5) は履歴画面の踏破済塗り・現在地マーカー・縁取りなど他の場所に残す。軌跡だけ別色化する設計。

## なぜマゼンタか

- 緑（高速道路）と補色 → 明確に分離
- 灰色（地形/等高線）と彩度差 → 埋もれない
- クリーム色（背景）とコントラスト十分
- オレンジは赤系の国道と被る可能性あり

## テスト

Vitest 122 件すべて pass（軌跡色は assertion 対象外、純粋に視覚変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)