### PR TITLE
fix(history): レベル 1/2 で対象エリア外を半透明黒でマスク (PC ワイド対策)

### DIFF
--- a/public/assets/history.js
+++ b/public/assets/history.js
@@ -370,6 +370,45 @@ function renderLevel0() {
   exposeForE2E();
 }
 
+/**
+ * 指定 feature 配列の geometry を「穴 (hole)」として、外側を半透明の黒で覆う
+ * マスクポリゴンを map に追加する。
+ * 「県外/地方外を暗くする」ことで、PC ワイドビュー時に対象エリア以外の地理院
+ * クリーム色背景が目立つ問題を解消する。
+ *
+ * Leaflet Polygon は [outer, ...holes] 形式で外周 + 穴を表現できる。
+ * GeoJSON [lon, lat] → Leaflet [lat, lon] 変換も同時に行う。
+ * 大きな outer ring は日本全土を覆う矩形（lat 20-50 / lon 120-150）。
+ *
+ * @param {Array<{geometry: object}>} features
+ * @returns {L.Polygon | null}
+ */
+function addOutsideMask(features) {
+  if (!features || features.length === 0) return null;
+  const holes = [];
+  for (const feature of features) {
+    const geom = feature?.geometry;
+    if (!geom) continue;
+    if (geom.type === 'Polygon') {
+      holes.push(geom.coordinates[0].map(([lon, lat]) => [lat, lon]));
+    } else if (geom.type === 'MultiPolygon') {
+      for (const poly of geom.coordinates) {
+        holes.push(poly[0].map(([lon, lat]) => [lat, lon]));
+      }
+    }
+  }
+  if (holes.length === 0) return null;
+  const outerRing = [[20, 120], [50, 120], [50, 150], [20, 150], [20, 120]];
+  const mask = L.polygon([outerRing, ...holes], {
+    fillColor: '#0a0a0c',
+    fillOpacity: 0.7,
+    stroke: false,
+    interactive: false,  // クリックを下層 polygon に通す
+  });
+  mask.addTo(historyMap);
+  return mask;
+}
+
 // === レベル 1: 地方 → 都道府県 ===
 
 function renderLevel1() {
@@ -383,6 +422,9 @@ function renderLevel1() {
       f => f.properties.region_code === currentRegion,
     ),
   };
+
+  // 地方外を暗くマスク（PC ワイド表示で他地方のクリーム色背景が目立つ問題対策）
+  addOutsideMask(filtered.features);
   const conquered = conquests.filter(c => c.region_code === currentRegion).length;
   const total = filtered.features.reduce(
     (sum, f) => sum + (f.properties.muni_count ?? 0), 0,
@@ -447,6 +489,8 @@ async function renderLevel2() {
   const prefFeature = prefectureGeo.features.find(
     f => f.properties.prefecture_code === currentPrefecture,
   );
+  // 県外を暗くマスク（クリーム色の他県背景を隠す）
+  if (prefFeature) addOutsideMask([prefFeature]);
   const prefName = prefFeature?.properties.name ?? currentPrefecture;
   setTitle(prefName);
 


### PR DESCRIPTION
## 概要

PC ワイド画面で履歴画面を開くと、対象県/地方の周囲（他県・海など）が地理院 pale のクリーム色のまま大きく見えて、「自分はどこを見ているか」が分かりにくい問題への対応。

## 修正

`addOutsideMask(features)` ヘルパーを追加し、レベル 1 / 2 の冒頭で対象エリアを「穴」とした半透明黒のマスクポリゴンを add。

- Leaflet Polygon の `[outer, ...holes]` 形式で「日本全土を覆う黒い outer + 対象 feature を hole」を表現
- `fillOpacity: 0.7` の半透明黒（`#0a0a0c`）
- `interactive: false` でタップを下層 polygon にスルー（既存タップロジックに影響なし）
- GeoJSON `[lon, lat]` → Leaflet `[lat, lon]` 変換も内部で実施

## レベル別の動作

- レベル 0（日本全土）: マスクなし（全体が主役）
- **レベル 1（地方）**: その地方内の都道府県を hole に → 他地方が暗くなる
- **レベル 2（都道府県）**: その県を hole に → 他県と海が暗くなる

## テスト

- Vitest フロント 122 件全 pass
- Playwright E2E (chromium-iphone-emulated) 4 件全 pass（mask 追加でもタップロジック影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)