### PR TITLE
fix(history): 詳細モーダルを body 直下に動的生成 (Chromium stacking バグ回避)

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -51,5 +51,18 @@ export default defineConfig({
         geolocation: { latitude: 36.0640, longitude: 139.6691 },
       },
     },
+    {
+      // PC ワイド画面 (Chromium) での検証用。履歴画面が PC で開かれる
+      // ケースで viewport が広いことに起因するレイアウト問題を再現する。
+      name: 'desktop-chromium',
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1456, height: 819 },
+        isMobile: false,
+        hasTouch: false,
+        permissions: ['geolocation'],
+        geolocation: { latitude: 36.0640, longitude: 139.6691 },
+      },
+    },
   ],
 });

--- a/public/index.html
+++ b/public/index.html
@@ -113,8 +113,10 @@
   <div id="history-map" class="history-map"></div>
   <div class="history-loading" style="display:none;">読み込み中…</div>
   <div class="history-error" style="display:none;"></div>
-  <div id="history-detail" class="history-detail" style="display:none;"></div>
 </section>
+<!-- 詳細モーダル (#history-detail) は history.js の renderLevel3 で動的生成し、
+     body 直下に配置する。#history-screen の中に置くと stacking context の
+     都合で画面上に描画されない不具合がある（PC ワイド検証で確認）。 -->
 
 <!-- Leaflet JS (CDN) -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"

--- a/tests/e2e/history.spec.js
+++ b/tests/e2e/history.spec.js
@@ -291,6 +291,28 @@ test.describe('踏破履歴ビュー E2E', () => {
     await expect(page.locator('#history-detail')).toBeVisible({ timeout: 3000 });
     await expect(page.locator('#history-detail')).toContainText(muniCenter.name);
 
+    // モーダル実際の表示状態を診断
+    const modalState = await page.evaluate(() => {
+      const el = document.getElementById('history-detail');
+      if (!el) return 'no element';
+      const cs = getComputedStyle(el);
+      const rect = el.getBoundingClientRect();
+      const card = el.firstElementChild;
+      const cardRect = card?.getBoundingClientRect();
+      return {
+        display: cs.display,
+        visibility: cs.visibility,
+        opacity: cs.opacity,
+        zIndex: cs.zIndex,
+        position: cs.position,
+        rect: { x: rect.x, y: rect.y, w: rect.width, h: rect.height },
+        cardRect: cardRect ? { x: cardRect.x, y: cardRect.y, w: cardRect.width, h: cardRect.height } : null,
+        innerHTMLLen: el.innerHTML.length,
+        bgColor: cs.backgroundColor,
+      };
+    });
+    console.log('MODAL STATE:', JSON.stringify(modalState, null, 2));
+
     await page.screenshot({ path: 'tests/e2e/results/history-03-detail-modal.png' });
   });
 });


### PR DESCRIPTION
## 概要

詳細モーダル (#history-detail) が DOM 上では `visible` 判定が通るのに、PC ワイド viewport で実画面には描画されない問題への対応。

## 原因

`<section id="history-screen">` (position: fixed; inset: 0; z-index: 10) の中に `<div id="history-detail">` (position: fixed; inset: 0; z-index: 20) を入れ子にすると、Chromium が両方の fixed/inset を合成する過程で実描画をスキップするケースがある。computed style は完全に正常（display: flex / visibility: visible / opacity: 1 / 正しい rect）でも、screenshot に映らない。

## 修正

- `public/index.html` から `<div id="history-detail">` の静的 DOM 宣言を削除
- `history.js:renderLevel3()` の動的生成パスに一本化（document.body 直下に append）
- これで stacking context が history-screen と独立、Chromium が正しく描画する

## 追加: PC ワイド検証用 E2E

- `playwright.config.js` に `desktop-chromium` project を追加（1456x819）
- `history.spec.js` に MODAL STATE 診断ログ（computed style + cardRect）
- 修正前は desktop screenshot にモーダル無し、修正後は中央に「神奈川県 川崎市」カードが見える

## テスト

- Vitest フロント 122 件 pass
- Playwright chromium-iphone-emulated 4 件 pass
- Playwright desktop-chromium レベル1→2→3 pass + screenshot で実視確認 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)