### PR TITLE
fix(history): レベル2 のマスクを市町村 polygon の集約で精細化 (県境ジャギ解消)

### DIFF
--- a/public/assets/history.js
+++ b/public/assets/history.js
@@ -491,8 +491,10 @@ async function renderLevel2() {
   const prefFeature = prefectureGeo.features.find(
     f => f.properties.prefecture_code === currentPrefecture,
   );
-  // 県外を暗くマスク（クリーム色の他県背景を隠す）
-  if (prefFeature) addOutsideMask([prefFeature]);
+  // 県外を暗くマスク（暫定: 粗い prefFeature で fetch 中の暗転を入れる）。
+  // 市町村 polygon の fetch 完了後に詳細マスクに置き換える。
+  let tempMask = null;
+  if (prefFeature) tempMask = addOutsideMask([prefFeature]);
   const prefName = prefFeature?.properties.name ?? currentPrefecture;
   setTitle(prefName);
 
@@ -547,6 +549,14 @@ async function renderLevel2() {
       return null;
     }
   }));
+
+  // 暫定の粗マスクを削除し、市町村 polygon の集約で詳細マスクに置き換える。
+  // 県境のジャギ（preprocess の tolerance 0.05 度起因の粗形）が消える。
+  if (tempMask) historyMap.removeLayer(tempMask);
+  const muniFeaturesForMask = fetched
+    .filter((item) => item && item.geo?.features?.[0]?.geometry)
+    .map((item) => ({ geometry: item.geo.features[0].geometry }));
+  addOutsideMask(muniFeaturesForMask);
 
   // Leaflet の同レイヤー内では「後から add した path が DOM 上で前面」になり、
   // タップ判定はその前面要素が優先される。並列 fetch で add 順がランダムだと


### PR DESCRIPTION
## 概要

PR #65 で県外を黒マスクしたが、mask の hole が `prefectures.geojson` (tolerance 0.05 度 ≈ 5.5km) の粗いポリゴンだったため、県境がカクカク見えて「ざっくり囲っているのがバレる」問題への対応。

## 修正

レベル 2 (renderLevel2) を 2 段階マスクに：

1. **fetch 中**: 粗い `prefFeature` で暫定マスク（即座に暗転を出す）
2. **市町村 fetch 完了後**: 全市町村 polygon の `geometry` を集約して詳細マスクに置換

市町村 polygon は `preprocess/split_and_simplify.py` で tolerance 0.0005 度（~55m）に簡略化済み。これを mask の hole として束ねるため、ピクセル精度で県境が滑らかになる。

## レベル別の対応

- レベル 0 (日本全土): マスクなし
- レベル 1 (地方): 都道府県 polygon の粗さが残る（ズームレベル的に目立たないため据え置き）
- **レベル 2 (都道府県)**: 市町村 polygon 集約マスクで滑らか化

## テスト

- Vitest 122 件全 pass
- Playwright desktop-chromium レベル1→2→3 pass、screenshot で詳細モーダル可視 + マスク輪郭滑らか化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)