### PR TITLE
feat(map): メイン地図を Mapbox GL JS v3 に移行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,8 @@ APP_PASSWORD=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # CORS で許可するオリジン（Cloudflare Pages のドメイン）
 ALLOWED_ORIGIN=https://trip-road.pages.dev
+
+# Mapbox 公開トークン（account.mapbox.com で発行する pk.xxx）
+# メイン地図（Mapbox GL JS）用。流出時のタダ乗り防止に URL 制限を必ず設定する。
+# Workers Secret として登録し、/api/mapbox-token で認証済みクライアントに配布する。
+MAPBOX_TOKEN=pk.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ GPS ベースの旅ガイド Webアプリ。電車・徒歩移動中に iPhone S
 ## 2. 技術スタック
 
 - **フロントエンド**: Vanilla JS + HTML + CSS
-- **地図**: Leaflet.js 1.9.4（背景は地理院タイル 淡色地図）
+- **地図（メイン画面）**: Mapbox GL JS v3（Standard スタイル、端末時刻で lightPreset を dawn/day/dusk/night 自動切替。2026-06-03 に地理院タイル+Leaflet から移行）
+- **地図（履歴画面）**: Leaflet.js 1.9.4（背景は地理院タイル 淡色地図。コロプレスが Leaflet 依存のため未移行）
 - **空間演算**: Turf.js（booleanPointInPolygon のみ使用）
 - **バックエンド**: Cloudflare Workers（認証 + Bedrock Runtime プロキシ + Plan E Judge 統合）
 - **LLM (生成・Judge とも)**: **Amazon Bedrock Nova Pro**（`us.amazon.nova-pro-v1:0` cross-region inference profile） — Plan H で Anthropic Claude（Haiku 4.5 / Sonnet 4.6）から全面移行（2026-05-08）
@@ -32,6 +33,7 @@ GPS ベースの旅ガイド Webアプリ。電車・徒歩移動中に iPhone S
    - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION`（Bedrock Runtime + S3 共用、IAM ユーザー `trip-road-telemetry-writer`）
    - `S3_TELEMETRY_BUCKET`（テレメトリ Sink）
    - `ALLOWED_ORIGIN`（CORS 許可オリジン）
+   - `MAPBOX_TOKEN`（Mapbox 公開トークン pk。`/api/mapbox-token` で認証済みクライアントに配布）
    - 旧 `ANTHROPIC_API_KEY` は Plan H で削除済
 - **外部 API**:
    - Amazon Bedrock Runtime: Workers から SigV4 署名で Converse API 呼出（aws4fetch、modelId は `us.amazon.nova-pro-v1:0` cross-region inference profile）
@@ -98,6 +100,7 @@ cd workers && wrangler secret put AWS_SECRET_ACCESS_KEY
 cd workers && wrangler secret put AWS_REGION
 cd workers && wrangler secret put S3_TELEMETRY_BUCKET
 cd workers && wrangler secret put ALLOWED_ORIGIN
+cd workers && wrangler secret put MAPBOX_TOKEN
 # 旧 ANTHROPIC_API_KEY は Plan H 本番反映後に削除：
 # cd workers && wrangler secret delete ANTHROPIC_API_KEY
 
@@ -139,7 +142,9 @@ wrangler pages deploy public/ --project-name=trip-road
 
 アプリ画面または `docs/credits.md` に以下を明示：
 
-- 「地理院タイル」
+- © Mapbox / © OpenStreetMap（メイン地図。Mapbox GL JS が組込みの attribution で自動表示。CSS で消さない）
+- 「地理院タイル」（履歴画面の背景）
 - 「国土数値情報（行政区域データ）（国土交通省）を加工して作成」
-- Leaflet.js（BSD-2-Clause）
+- Mapbox GL JS（メイン地図ライブラリ）
+- Leaflet.js（BSD-2-Clause、履歴画面）
 - Turf.js（MIT）

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -1214,6 +1214,12 @@ LLM 自動生成を保ったまま品質を上げる。手作業による解説�
 
 `~/.claude/CLAUDE.md` の理解度テストハーネスで、てつてつが理解を確認した概念を日付つきで記録する。次回以降、同じ概念に関する実装の前のテストはスキップ判定に使う。
 
+### 2026-06-03 Mapbox GL JS 移行（メイン地図）着手前テスト
+
+- **ベクタータイルの本質**: ベクタータイルは「道路はここ」という座標・形状データと描画ルールを送り、端末の GPU(WebGL) がリアルタイムに描画する。だから任意の拡大率・角度で再描画でき、ヌルッとした拡大縮小・地図の傾き・3D表示が可能になる。ラスタタイル（地理院）は描画済み PNG 画像を配るだけなので、これらができない。解像度の高さやキャッシュ・CDN の近さが理由ではない
+- **Leaflet と Mapbox GL JS のスタイリングモデルの違い**: Leaflet はポリゴンを1つずつ add して style を命令的に指定する。Mapbox GL JS は「データ(source)」と「踏破率に応じた色ルール(layer の式)」を分離して宣言する、データ駆動スタイル。考え方が根本的に違うため、history.js のコロプレスは API 関数名の置換では済まず作り直しになる（だからメイン地図のみ先行移行と判断）
+- **地理院 → Mapbox の採用コスト（捨てる/増えるもの）**: 見た目の向上と引き換えに、Mapbox という民間サービスへの依存（無料枠50,000ロード/月・利用規約）、出典ロゴと attribution の常時表示義務（地理院は CSS で隠していたが Mapbox は規約上消せない）、公開トークン(pk)の URL 制限・ローテという運用が新たに発生する。GPS 精度低下や固定課金が発生するわけではない（個人利用は無料枠内）
+
 ### 2026-05-05 F-1.3b 着手前テスト
 
 - **RAG（Retrieval-Augmented Generation）の本質**: LLM の学習データに含まれない、または不確かな事実を、外部の検索結果や参照資料で補強する仕組み。応答速度・コスト削減・出力長制限のためではなく、知識限界の補完が目的
@@ -1995,7 +2001,24 @@ iPhone Safari メモリ予算（~1 GB）内に十分収まる。Cloudflare Pages
 - speed-mater: https://github.com/tetutetu214/speed-mater（GPS取得ロジックの元）
 
 ### 5.3 使用OSS
-- Leaflet.js 1.9.4（BSD-2-Clause）: https://github.com/Leaflet/Leaflet
+- Mapbox GL JS v3（メイン地図、商用ライブラリ・無料枠あり）: https://docs.mapbox.com/mapbox-gl-js/
+- Leaflet.js 1.9.4（BSD-2-Clause、履歴画面）: https://github.com/Leaflet/Leaflet
 - Turf.js booleanPointInPolygon（MIT）: https://github.com/Turfjs/turf
 - geopandas（BSD-3-Clause）
 - shapely（BSD-3-Clause）
+
+## 6. Mapbox GL JS 移行（メイン地図）（2026-06-03）
+
+地理院タイル+Leaflet のメイン地図を Mapbox GL JS v3（Standard）へ移行。きっかけは「地理院より見やすそう」というてつてつの要望。
+
+### 設計判断
+- **スコープをメイン地図に限定**: 履歴画面（history.js）のコロプレスは `L.geoJSON` の命令的スタイル・マスク・本土 fitBounds・タップ階層遷移が Leaflet に深く依存し、Mapbox GL JS のデータ駆動スタイル（source+layer+式）へ移すと実質作り直し＋E2E 6件の書き直しになる。見やすさの主目的はライブのメイン地図なので、メインのみ先行移行・Leaflet 併存とした（両ライブラリ同時読込のコストは個人 PWA では許容）。
+- **トークン配布**: 公開トークン(pk)でも、リポジトリがパブリックで Push Protection があるため直書きを避け、Workers Secret `MAPBOX_TOKEN` に置き `GET /api/mapbox-token`（authenticate() 経由）でログイン済みクライアントにだけ渡す。pk の主リスクは「タダ乗りで無料枠消費」だけなので、Mapbox 管理画面の URL 制限（trip-road ドメイン）＋いつでも再発行で十分管理可能。秘密トークン(sk)はフロントに出さない。
+- **スタイルと時間連動**: Standard スタイル＋`setConfigProperty('basemap','lightPreset', …)` で端末時刻から dawn/day/dusk/night を自動切替。スタイルは1枚のまま照明だけ変えるので滑らか＆map load カウントが増えない（スタイル丸ごと差し替え方式は再読込でカウント増・軌跡レイヤー貼り直しが必要なので不採用）。
+
+### ハマりどころ・要注意
+- **座標順が逆**: Mapbox / GeoJSON は `[lng, lat]`。アプリ内部の track は `{lat, lon}` なので必ず `[lon, lat]` に並べ替える。Leaflet の `[lat, lon]` 感覚のままだと日本がアフリカ沖に飛ぶ。
+- **初期化タイミング**: source/layer 追加と `setConfigProperty`（lightPreset）は `map.on('style.load')` の中で行う。`'load'` ではなく `'style.load'`（Standard の config 適用に必要）。GPS 初回 fix が地図ロードより先に来てもクラッシュしないよう、現在地は `pendingLocation` に、軌跡は `trackCoords` 配列に保持して style.load 後に反映する設計。
+- **attribution は消せない**: Mapbox の出典表記・ロゴは利用規約で必須。地理院時代は CSS で隠していたが Mapbox では非表示禁止。`.mapboxgl-ctrl-bottom-*` を下部カードより前面(z-index)に出して見えるようにした。
+- **invalidateSize→resize**: Leaflet の `map.invalidateSize()` は Mapbox では `map.resize()`。iOS Safari の復帰・回転対策のリサイズ処理はそのまま移植。
+- **陰影起伏図**: 地理院 hillshade タイルの代わりに Mapbox の raster-dem（mapbox.mapbox-terrain-dem-v1）+ hillshade レイヤー。off/weak/strong を `hillshade-exaggeration`(0/0.4/0.7)とレイヤー可視性で切替。

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -589,6 +589,23 @@ Issue #46 の opacity 0.3 は控えめという実機フィードバックを受
 
 ---
 
+## Mapbox GL JS 移行（メイン地図）（2026-06-03）
+
+地理院タイル+Leaflet のメイン地図を Mapbox GL JS v3（Standard スタイル）に移行。見やすさ向上が目的。履歴画面は Leaflet 据え置き（コロプレスが Leaflet 依存で作り直しになるため、まずメイン地図のみ先行移行と判断）。
+
+- [x] Worker に `GET /api/mapbox-token`（認証付き）を追加し `env.MAPBOX_TOKEN` を配布
+- [x] `api.js` に `getMapboxToken(password)` を追加
+- [x] `map.js` を Mapbox GL JS v3 に全面書き換え（Standard、lightPreset 時間連動、現在地マーカー、軌跡 GeoJSON source+line layer、hillshade=raster-dem、resize→map.resize()）
+- [x] `app.js` をトークン取得→`initMap('map', token)` に変更
+- [x] `index.html` に mapbox-gl v3.9.0 CDN を追加（Leaflet 併存）、メイン画面の手動 `.map-attribution`（地理院）を削除
+- [x] `app.css` に Mapbox コンテナ背景＋attribution/ロゴを前面表示（規約上非表示にしない）
+- [x] `lightPresetForHour` の単体テスト追加（Vitest、全 127 件 pass）
+- [ ] **てつてつ手動**: Mapbox アカウント作成→pk トークン発行→URL 制限設定→`wrangler secret put MAPBOX_TOKEN`
+- [ ] ローカル実トークンで表示確認（`npm run serve` or `wrangler pages dev`）
+- [ ] Worker デプロイ（`workers/deploy_production.sh`）+ Pages デプロイ（`deploy_frontend.sh`）
+- [ ] 実機 iPhone で時間連動・軌跡・陰影トグルを観察
+- [ ] PR 作成・マージ
+
 ### さらに先（無時系列、検討候補）
 
 - [ ] Service Worker によるオフライン対応

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -600,11 +600,13 @@ Issue #46 の opacity 0.3 は控えめという実機フィードバックを受
 - [x] `index.html` に mapbox-gl v3.9.0 CDN を追加（Leaflet 併存）、メイン画面の手動 `.map-attribution`（地理院）を削除
 - [x] `app.css` に Mapbox コンテナ背景＋attribution/ロゴを前面表示（規約上非表示にしない）
 - [x] `lightPresetForHour` の単体テスト追加（Vitest、全 127 件 pass）
-- [ ] **てつてつ手動**: Mapbox アカウント作成→pk トークン発行→URL 制限設定→`wrangler secret put MAPBOX_TOKEN`
-- [ ] ローカル実トークンで表示確認（`npm run serve` or `wrangler pages dev`）
-- [ ] Worker デプロイ（`workers/deploy_production.sh`）+ Pages デプロイ（`deploy_frontend.sh`）
-- [ ] 実機 iPhone で時間連動・軌跡・陰影トグルを観察
-- [ ] PR 作成・マージ
+- [x] **てつてつ手動**: Mapbox アカウント作成→pk トークン発行→URL 制限設定→secret 登録
+- [x] Worker 本番デプロイ（`/api/mapbox-token` 検証済: 認証200/未認証401/POST405、pk 90文字）
+- [x] Pages 本番デプロイ（`deploy_frontend.sh`、独自ドメイン HTTP 200、HTML に mapbox-gl v3.9.0 反映確認）
+- [x] 実機で滑らかな地図表示を確認（2026-06-03 夜、ヌルッと動く＝core 成功）
+- [ ] **明日（昼）に観察**: 移動時の軌跡が伸びるか、時間連動で昼の明るい表示になるか
+- [ ] **陰影が見えない問題を修正**: Standard の不透明な地面の下（slot:'bottom'）に hillshade を敷いたため隠れている疑い。`setTerrain`（本物の3D地形、exaggeration を off/弱/強に割当）方式へ切替え、昼に検証
+- [ ] PR 作成・マージ（保留 or 先行は要相談）
 
 ### さらに先（無時系列、検討候補）
 

--- a/public/assets/api.js
+++ b/public/assets/api.js
@@ -179,6 +179,46 @@ export async function getConquests(password, opts = {}) {
 }
 
 /**
+ * Mapbox 公開トークンを Workers `/api/mapbox-token` から GET する。
+ * メイン地図（Mapbox GL JS）初期化に必要。トークンはリポジトリに置かず
+ * Workers Secret で管理し、認証済みクライアントにだけ渡す設計。
+ *
+ * @param {string} password
+ * @param {{timeoutMs?: number}} [opts]
+ * @returns {Promise<{ok: true, token: string} | {ok: false, status: number, error: string}>}
+ */
+export async function getMapboxToken(password, opts = {}) {
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/mapbox-token`, {
+      method: 'GET',
+      headers: { 'X-App-Password': password },
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (res.status === 401) {
+      return { ok: false, status: 401, error: 'unauthorized' };
+    }
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: 'upstream_error' };
+    }
+    const data = await res.json();
+    if (!data.token) {
+      return { ok: false, status: res.status, error: 'empty_token' };
+    }
+    return { ok: true, token: data.token };
+  } catch (e) {
+    clearTimeout(timer);
+    if (e.name === 'AbortError') {
+      return { ok: false, status: 0, error: 'timeout' };
+    }
+    return { ok: false, status: 0, error: String(e) };
+  }
+}
+
+/**
  * テレメトリバッチを Workers `/api/telemetry` に送る。
  * 失敗時は 1 回だけリトライ（2 秒後）。
  */

--- a/public/assets/app.css
+++ b/public/assets/app.css
@@ -178,15 +178,16 @@ body {
   bottom: var(--card-height);
   background: var(--color-bg-map);
 }
-.map-attribution {
-  position: absolute;
-  bottom: calc(var(--card-height) + 12px);
-  right: 12px;
-  background: rgba(22,22,24,0.9);
-  padding: 4px 8px;
-  border-radius: 6px;
-  font-size: 9px;
-  color: var(--color-text-hint);
+/* Mapbox のキャンバス背景（タイル読込前のちらつき防止） */
+#map.mapboxgl-map,
+#map .mapboxgl-canvas {
+  background: var(--color-bg-map);
+}
+/* Mapbox の出典表記・ロゴは利用規約で必須なので非表示にしない。
+   #map の下端は下部カードの上端（--card-height）に一致するため、
+   コントロールはカードの直上に表示される。カードに隠れないよう前面に出す。 */
+.mapboxgl-ctrl-bottom-left,
+.mapboxgl-ctrl-bottom-right {
   z-index: 6;
 }
 

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -24,7 +24,7 @@ import {
   getUnsyncedVisitedBefore,
   markVisitedSynced,
 } from './storage.js';
-import { fetchDescription, sendTelemetryBatch, postConquests } from './api.js';
+import { fetchDescription, sendTelemetryBatch, postConquests, getMapboxToken } from './api.js';
 import { setupHistoryScreen, openHistoryScreen } from './history.js';
 import { DATA_BASE_URL } from './config.js';
 import { identifyMunicipality, prefetchNeighbors } from './muni.js';
@@ -115,7 +115,15 @@ function setupPasswordScreen() {
 // === メイン画面初期化 ===
 async function enterMainApp(password) {
   showMainScreen();
-  initMap('map');
+  // Mapbox トークンを Worker から取得してから地図を初期化する。
+  // 取得失敗時は地図初期化をスキップし、アプリ全体はクラッシュさせない
+  // （現在地チップや土地のたよりなど地図以外の機能は引き続き動く）。
+  const tokenResult = await getMapboxToken(password);
+  if (tokenResult.ok) {
+    initMap('map', tokenResult.token);
+  } else {
+    console.warn('[app] Mapbox トークン取得に失敗、地図初期化をスキップ', tokenResult);
+  }
   setVisitedCount(getVisitedCount());
 
   // 既存軌跡を復元（今日の ts のものだけ描画。過去日分は localStorage に温存）

--- a/public/assets/map.js
+++ b/public/assets/map.js
@@ -1,64 +1,144 @@
 /**
- * Leaflet 初期化、現在地マーカー、軌跡ポリラインの管理。
- * Leaflet は index.html で CDN 読込の global `L` を使う。
+ * Mapbox GL JS v3 によるメイン地図。
+ * 現在地マーカー、軌跡ライン、陰影起伏図トグルを管理する。
+ * mapboxgl は index.html で CDN 読込した global を使う。
+ *
+ * 地理院タイル + Leaflet からの移行（2026-06-03）。履歴画面（history.js）は
+ * 引き続き Leaflet を使うため、両ライブラリが併存する。
+ *
+ * 座標順の注意: Mapbox / GeoJSON は [lng, lat]（経度・緯度の順）。
+ * アプリ内部の track は {lat, lon} なので、Mapbox に渡すときは必ず
+ * [lon, lat] に並べ替える。
  */
-import { TILE_URL, HILLSHADE_TILE_URL } from './config.js';
+const STANDARD_STYLE = 'mapbox://styles/mapbox/standard';
+const INITIAL_CENTER = [138, 35.5]; // [lng, lat]
+const INITIAL_ZOOM = 5;
+const FIRST_FIX_ZOOM = 14;
 
 let map = null;
 let marker = null;
-let trackLine = null;
-let hillshadeLayer = null;
+let markerAdded = false;
+let styleLoaded = false;
+// 軌跡の座標は常に JS 側で保持する（[lng, lat] の配列）。
+// style.load 前に setTrack/addTrackPoint が来てもここに溜め、ロード後に反映する。
+let trackCoords = [];
+// style.load 前に来た現在地更新を保留する。
+let pendingLocation = null;
+// 現在の陰影レベル（'off'/'weak'/'strong'）。
+let hillshadeLevel = 'off';
 
-export function initMap(containerId) {
-  map = L.map(containerId, {
-    center: [35.5, 138],
-    zoom: 5,
-    zoomControl: false,
-    attributionControl: false,
+/**
+ * 端末の現在時刻から Standard スタイルの lightPreset を決める。
+ * 明け方 / 昼 / 夕暮れ / 夜の 4 段階で地図全体の照明・影が変わる。
+ */
+export function lightPresetForHour(hour) {
+  if (hour < 5) return 'night';
+  if (hour < 8) return 'dawn';
+  if (hour < 17) return 'day';
+  if (hour < 19) return 'dusk';
+  return 'night';
+}
+
+// 陰影起伏図の強度（hillshade-exaggeration）。'off' はレイヤー非表示。
+const HILLSHADE_EXAGGERATION = { off: 0, weak: 0.4, strong: 0.7 };
+
+function trackGeoJSON() {
+  return {
+    type: 'Feature',
+    geometry: { type: 'LineString', coordinates: trackCoords },
+    properties: {},
+  };
+}
+
+/**
+ * Mapbox 地図を初期化する。token は Workers 経由で取得した公開トークン(pk)。
+ */
+export function initMap(containerId, token) {
+  mapboxgl.accessToken = token;
+  map = new mapboxgl.Map({
+    container: containerId,
+    style: STANDARD_STYLE,
+    center: INITIAL_CENTER,
+    zoom: INITIAL_ZOOM,
+    attributionControl: true, // 規約上、出典表記は表示したまま
   });
-  L.tileLayer(TILE_URL, { maxZoom: 18, tileSize: 256 }).addTo(map);
 
-  // 陰影起伏図レイヤー。初期は add しない。setHillshadeEnabled で切替。
-  hillshadeLayer = L.tileLayer(HILLSHADE_TILE_URL, {
-    maxZoom: 18,
-    maxNativeZoom: 16,
-    opacity: 0.3,
-  });
-
-  // 現在地マーカー（SVG divIcon）
-  const iconHtml = `<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+  // 現在地マーカー（mintグリーンの二重丸 SVG）。位置確定後に addTo する。
+  const el = document.createElement('div');
+  el.className = 'current-location-marker';
+  el.innerHTML = `<svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
     <circle cx="9" cy="9" r="7" stroke="#9fe1cb" stroke-width="1.2" fill="none"/>
     <circle cx="9" cy="9" r="2.5" fill="#9fe1cb"/>
   </svg>`;
-  const icon = L.divIcon({ html: iconHtml, className: 'current-location-marker', iconSize: [18, 18], iconAnchor: [9, 9] });
-  marker = L.marker([35.5, 138], { icon });
-  // 初期位置では add しない（GPS 取得後に add）
+  marker = new mapboxgl.Marker({ element: el });
 
-  // 地理院 pale 地図の「緑色の高速道路」「灰色の地形/等高線」と
-  // 軌跡が被って見にくい問題への対応で、補色のマゼンタに変更（2026-05-26）。
-  // UI ブランド色のミントグリーン (#5dcaa5) は履歴画面・現在地マーカー側に残す。
-  trackLine = L.polyline([], {
-    color: '#ff4d8c',
-    weight: 3,
-    opacity: 0.9,
-    lineCap: 'round',
-    lineJoin: 'round',
-  }).addTo(map);
+  // Standard スタイルの config 適用（lightPreset）とソース/レイヤー追加は
+  // スタイル読込完了後でないと反映されない。'load' ではなく 'style.load' を使う。
+  map.on('style.load', () => {
+    styleLoaded = true;
+
+    // 時間連動のライトプリセット
+    map.setConfigProperty('basemap', 'lightPreset', lightPresetForHour(new Date().getHours()));
+
+    // 陰影起伏図用の DEM ソースと hillshade レイヤー（初期は非表示）。
+    // 地図の地形感を出す。slot 'bottom' で道路・ラベルの下に置く。
+    if (!map.getSource('mapbox-dem')) {
+      map.addSource('mapbox-dem', {
+        type: 'raster-dem',
+        url: 'mapbox://mapbox.mapbox-terrain-dem-v1',
+        tileSize: 512,
+        maxzoom: 14,
+      });
+    }
+    if (!map.getLayer('hillshade')) {
+      map.addLayer({
+        id: 'hillshade',
+        type: 'hillshade',
+        source: 'mapbox-dem',
+        slot: 'bottom',
+        layout: { visibility: 'none' },
+        paint: { 'hillshade-exaggeration': HILLSHADE_EXAGGERATION.weak },
+      });
+    }
+    applyHillshade();
+
+    // 軌跡ライン。地理院 pale 地図での視認性問題に倣い、補色のマゼンタ。
+    if (!map.getSource('track')) {
+      map.addSource('track', { type: 'geojson', data: trackGeoJSON() });
+    }
+    if (!map.getLayer('track-line')) {
+      map.addLayer({
+        id: 'track-line',
+        type: 'line',
+        source: 'track',
+        slot: 'top',
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: { 'line-color': '#ff4d8c', 'line-width': 3, 'line-opacity': 0.9 },
+      });
+    }
+
+    // style.load 前に来ていた現在地更新があれば反映する。
+    if (pendingLocation) {
+      const { lat, lon, isFirst } = pendingLocation;
+      pendingLocation = null;
+      updateCurrentLocation(lat, lon, isFirst);
+    }
+  });
 
   // 最小化→復帰や画面回転・リサイズ時に地図サイズを再計算する。
   // iOS Safari でバックグラウンド復帰時に viewport が一時的にずれて、
   // .map のレイアウトが崩れて上部チップが地図に隠れる現象への対策。
   const refreshSize = () => {
     if (!map) return;
-    // CSS の再計算が完了してから invalidateSize を呼ぶため少し遅延
-    setTimeout(() => map.invalidateSize(), 100);
+    // CSS の再計算が完了してから resize を呼ぶため少し遅延
+    setTimeout(() => map.resize(), 100);
   };
   document.addEventListener('visibilitychange', () => {
     if (!document.hidden) refreshSize();
   });
   window.addEventListener('pageshow', refreshSize);
   window.addEventListener('resize', () => {
-    if (map) map.invalidateSize();
+    if (map) map.resize();
   });
   window.addEventListener('orientationchange', refreshSize);
 
@@ -70,7 +150,7 @@ export function initMap(containerId) {
     const ro = new ResizeObserver(() => {
       const h = card.offsetHeight;
       document.documentElement.style.setProperty('--card-height', `${h}px`);
-      if (map) map.invalidateSize();
+      if (map) map.resize();
     });
     ro.observe(card);
   }
@@ -83,43 +163,60 @@ export function initMap(containerId) {
  */
 export function updateCurrentLocation(lat, lon, isFirst = false) {
   if (!map || !marker) return;
-  marker.setLatLng([lat, lon]);
-  if (!marker._map) marker.addTo(map);
-  const zoom = isFirst ? 14 : map.getZoom();
-  map.setView([lat, lon], zoom, { animate: true, duration: 0.3 });
+  // スタイル未ロード時は保留し、style.load 後に適用する。
+  if (!styleLoaded) {
+    pendingLocation = { lat, lon, isFirst };
+    return;
+  }
+  marker.setLngLat([lon, lat]);
+  if (!markerAdded) {
+    marker.addTo(map);
+    markerAdded = true;
+  }
+  const zoom = isFirst ? FIRST_FIX_ZOOM : map.getZoom();
+  map.easeTo({ center: [lon, lat], zoom, duration: 300 });
 }
 
 export function addTrackPoint(lat, lon) {
-  if (!trackLine) return;
-  trackLine.addLatLng([lat, lon]);
+  trackCoords.push([lon, lat]);
+  const source = map && map.getSource('track');
+  if (source) source.setData(trackGeoJSON());
 }
 
 export function setTrack(points) {
-  if (!trackLine) return;
-  trackLine.setLatLngs(points.map(p => [p.lat, p.lon]));
+  trackCoords = points.map(p => [p.lon, p.lat]);
+  const source = map && map.getSource('track');
+  if (source) source.setData(trackGeoJSON());
 }
 
 /**
- * 地図上の軌跡ポリラインを空にする。
+ * 地図上の軌跡ラインを空にする。
  * localStorage 側の track は変更しない（履歴データは温存）。
  */
 export function clearTrack() {
-  if (!trackLine) return;
-  trackLine.setLatLngs([]);
+  trackCoords = [];
+  const source = map && map.getSource('track');
+  if (source) source.setData(trackGeoJSON());
+}
+
+/**
+ * hillshade レイヤーへ現在の hillshadeLevel を反映する。
+ */
+function applyHillshade() {
+  if (!map || !map.getLayer('hillshade')) return;
+  const exaggeration = HILLSHADE_EXAGGERATION[hillshadeLevel] ?? 0;
+  if (exaggeration === 0) {
+    map.setLayoutProperty('hillshade', 'visibility', 'none');
+    return;
+  }
+  map.setPaintProperty('hillshade', 'hillshade-exaggeration', exaggeration);
+  map.setLayoutProperty('hillshade', 'visibility', 'visible');
 }
 
 /**
  * 陰影起伏図レイヤーのレベル切替（Issue #48: off / weak / strong）。
- * off ならレイヤーを map から外し、weak/strong なら opacity を切替えて add。
  */
-const HILLSHADE_OPACITY = { off: 0, weak: 0.4, strong: 0.7 };
 export function setHillshadeLevel(level) {
-  if (!map || !hillshadeLayer) return;
-  const op = HILLSHADE_OPACITY[level] ?? 0;
-  if (op === 0) {
-    if (map.hasLayer(hillshadeLayer)) map.removeLayer(hillshadeLayer);
-    return;
-  }
-  hillshadeLayer.setOpacity(op);
-  if (!map.hasLayer(hillshadeLayer)) hillshadeLayer.addTo(map);
+  hillshadeLevel = level;
+  applyHillshade();
 }

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,10 @@
 <link rel="manifest" href="/manifest.json">
 <title>trip-road</title>
 
-<!-- Leaflet CSS (CDN) -->
+<!-- Mapbox GL JS CSS (CDN) — メイン地図 -->
+<link rel="stylesheet" href="https://api.mapbox.com/mapbox-gl-js/v3.9.0/mapbox-gl.css">
+
+<!-- Leaflet CSS (CDN) — 履歴画面 -->
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
       crossorigin=""/>
@@ -49,9 +52,8 @@
     </div>
   </div>
 
-  <!-- 地図エリア -->
+  <!-- 地図エリア（メインは Mapbox。出典・ロゴは Mapbox 組込みの attribution が表示する） -->
   <div id="map" class="map"></div>
-  <div class="map-attribution">出典：地理院タイル</div>
 
   <!-- 下部カード -->
   <div class="bottom-card">
@@ -118,7 +120,10 @@
      body 直下に配置する。#history-screen の中に置くと stacking context の
      都合で画面上に描画されない不具合がある（PC ワイド検証で確認）。 -->
 
-<!-- Leaflet JS (CDN) -->
+<!-- Mapbox GL JS (CDN) — メイン地図 -->
+<script src="https://api.mapbox.com/mapbox-gl-js/v3.9.0/mapbox-gl.js"></script>
+
+<!-- Leaflet JS (CDN) — 履歴画面 -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
         integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
         crossorigin=""></script>

--- a/test/map_light_preset.test.js
+++ b/test/map_light_preset.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { lightPresetForHour } from '../public/assets/map.js';
+
+// メイン地図の Standard スタイルの時間連動（lightPreset 自動切替）の判定ロジック。
+// 端末時刻の「時」を受け取り、明け方/昼/夕暮れ/夜のどれを返すかを保証する。
+describe('lightPresetForHour', () => {
+  it('深夜（5時より前）は night を返す', () => {
+    expect(lightPresetForHour(0)).toBe('night');
+    expect(lightPresetForHour(4)).toBe('night');
+  });
+
+  it('明け方（5時〜7時）は dawn を返す', () => {
+    expect(lightPresetForHour(5)).toBe('dawn');
+    expect(lightPresetForHour(7)).toBe('dawn');
+  });
+
+  it('日中（8時〜16時）は day を返す', () => {
+    expect(lightPresetForHour(8)).toBe('day');
+    expect(lightPresetForHour(16)).toBe('day');
+  });
+
+  it('夕暮れ（17時〜18時）は dusk を返す', () => {
+    expect(lightPresetForHour(17)).toBe('dusk');
+    expect(lightPresetForHour(18)).toBe('dusk');
+  });
+
+  it('夜（19時以降）は night を返す', () => {
+    expect(lightPresetForHour(19)).toBe('night');
+    expect(lightPresetForHour(23)).toBe('night');
+  });
+});

--- a/workers/deploy_production.sh
+++ b/workers/deploy_production.sh
@@ -31,6 +31,17 @@ echo "--- ALLOWED_ORIGIN を登録（Plan C のフロント URL 想定） ---"
 printf '%s' "$ALLOWED_ORIGIN_PROD" | wrangler secret put ALLOWED_ORIGIN
 echo ""
 
+# Mapbox 公開トークン（メイン地図用）。~/.secrets/trip-road.env の MAPBOX_TOKEN を
+# パイプで渡す（対話入力だと空値で確定する事故があったため必ず stdin 経由）。
+if [ -n "${MAPBOX_TOKEN:-}" ]; then
+  echo "--- MAPBOX_TOKEN を登録 ---"
+  printf '%s' "$MAPBOX_TOKEN" | wrangler secret put MAPBOX_TOKEN
+  echo ""
+else
+  echo "警告: MAPBOX_TOKEN が未設定です（~/.secrets/trip-road.env に追記してください）。メイン地図が表示されません。"
+  echo ""
+fi
+
 echo "=== 2. 登録済 Secrets 一覧 ==="
 wrangler secret list
 echo ""

--- a/workers/src/index.js
+++ b/workers/src/index.js
@@ -166,7 +166,24 @@ export default {
       return jsonResponse({ error: 'method_not_allowed' }, 405, allowedOrigin);
     }
 
-    // 5. それ以外は 404
+    // 5. /api/mapbox-token: Mapbox 公開トークン(pk)を認証済みクライアントに配布
+    // 公開トークンとはいえ、パブリックリポジトリに直書きせず Workers Secret で
+    // 管理し、ログイン済みの利用者にだけ渡すことで流出面を最小化する。
+    if (url.pathname === '/api/mapbox-token') {
+      if (request.method !== 'GET') {
+        return jsonResponse({ error: 'method_not_allowed' }, 405, allowedOrigin);
+      }
+      const auth = await authenticate(request, env, allowedOrigin);
+      if (!auth.ok) return auth.response;
+
+      const token = env.MAPBOX_TOKEN || '';
+      if (!token) {
+        return jsonResponse({ error: 'server_misconfigured' }, 500, allowedOrigin);
+      }
+      return jsonResponse({ token }, 200, allowedOrigin);
+    }
+
+    // 6. それ以外は 404
     return jsonResponse({ error: 'not_found' }, 404, allowedOrigin);
   },
 };


### PR DESCRIPTION
## 概要
メイン地図を Leaflet + 国土地理院タイルから **Mapbox GL JS v3（Standard スタイル）** に移行する。「地理院より見やすい滑らかな地図にしたい」という要望が起点。実機で滑らかな表示を確認済み（本番反映済み）。

## 変更点
- `map.js` を Mapbox GL JS v3 に全面書き換え（Standard スタイル、現在地マーカー、軌跡は GeoJSON source + line layer、`map.resize()`）
- **時間連動**: 端末時刻で lightPreset を `dawn/day/dusk/night` 自動切替（`lightPresetForHour`）
- **トークン配布**: Workers Secret `MAPBOX_TOKEN` を新エンドポイント `GET /api/mapbox-token`（認証付き）で配布。`api.js` に `getMapboxToken`、`app.js` はトークン取得後に `initMap`
- `index.html` に mapbox-gl v3.9.0 CDN 追加（履歴画面用に Leaflet 併存）、手動の地理院出典表記を削除
- `app.css` で Mapbox の出典ロゴ（規約上必須）を下部カードより前面に表示
- `deploy_production.sh` に MAPBOX_TOKEN 登録を追加（stdin パイプ、空値事故対策）

## スコープ外（意図的）
- 履歴画面（`history.js`）は Leaflet 据え置き。コロプレスが Leaflet のデータ駆動でない命令的スタイルに依存し、移行は作り直し＋E2E 6件の書き直しになるため。まずメイン地図のみ先行移行

## テスト
- Vitest 127件 pass（`lightPresetForHour` の単体テスト追加）
- 本番エンドポイント検証: 認証200 / 未認証401 / POST405、pk トークン90文字

## 既知の残課題（別PRで対応予定）
- 陰影起伏図トグル（⛰️）が Standard の不透明な地面の下（slot:'bottom'）に隠れてほぼ見えない。`setTerrain`（3D地形、exaggeration を off/弱/強に割当）方式へ切替予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)