### PR TITLE
feat(rating): 👍/👎 明示フィードバックボタンを追加 (Issue #17)

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -2089,3 +2089,21 @@ iPhone Safari メモリ予算（~1 GB）内に十分収まる。Cloudflare Pages
 - **起動時の画**: 以前は `center [138,35.5] / zoom 5`（関東全体）から GPS 確定で `easeTo` ズーム。日本全体（`center [137.5,37.5] / zoom 4`）始まりに変え、初回 fix を `flyTo`(duration 3500, curve 1.6) にして「日本全体→現在地へ寄る」演出にした。2回目以降の追従は従来どおり `easeTo` で現ズーム維持。
 - **陰影の誇張不足**: weak0.4/strong0.7 は効果が薄かったため weak0.7/strong1.0（上限）に引き上げ。デフォルトは off 据え置き（てつてつ判断）。
 - **トグル時の「一瞬濃く→薄く」ちらつき**: paint プロパティは Mapbox 既定で約300msアニメーションする。OFF時は `visibility:none` にするだけで `hillshade-exaggeration` の値は前回(strong=1.0)が残るため、次の OFF→弱 表示時に 1.0→0.7 のアニメが走り、表示瞬間に濃く出てから薄く落ちる。`paint` に **`'hillshade-exaggeration-transition': { duration: 0 }`** を入れて値をスナップさせれば消える。色付きレイヤーの値を JS から動的に切り替えるときは、この既定トランジションの存在に注意。
+
+## 7. Issue #17 👍/👎 明示フィードバックボタン（2026-06-07）
+
+### 設計
+
+「土地のたより」カードに 👍/👎 を付け、表示中 entry の `user_rating`（'up'/'down'/null）をテレメトリに記録する。用途は **集計のみ**（Athena で `WHERE user_rating='down'` を抽出し、Plan I が苦手な市町村パターンを特定）。👍 を LLM の Few-shot 学習素材にする経路（#18）は、Plan I の「Wikipedia 抜粋を唯一の情報源にする in-context 要約特化」と相性が悪い（抜粋外の表現を誘発し忠実性を崩す）ため不採用。
+
+- **Worker 変更不要**: `/api/telemetry` は受け取った `entries` 配列を中身を見ずに `JSON.stringify` して S3 PUT するだけ。フロントが entry に `user_rating` を入れれば自動で永続化される。`user_rating` フィールド自体は Plan D Stage 1 で器だけ用意済だった。
+- **トグルは純粋関数**: `nextRating(current, clicked)` を `telemetry.js` に切り出し（同ボタン再タップで null に戻す）、Vitest でテスト。
+- **表示制御**: `ui.js` に `setRatingState`/`showRating`/`hideRating`。有効な解説が出たとき（キャッシュ/生成成功で `currentTraceId` あり）だけ表示。ローディング・記事なし・失敗時は隠す。市町村切替で新 trace_id 発行時に `currentRating=null` リセット＋一旦 hide。
+- **flush は既存経路に委譲**: rating は `updateTelemetry` で localStorage に反映するだけ。表示中 entry は `dwell_ms` 未確定のため flush 対象外で、市町村切替・60秒タイマーで送信される（評価しても即送信されないのは仕様通り）。
+- UI: カード右下、48×48px タップ領域、active 時に 👍=緑 / 👎=赤の薄背景。
+
+### 学習済み概念（理解度テスト 2026-06-07 全問正解、PR 直前テストはこの記録によりスキップ可）
+
+- **テレメトリ記録の仕組み**: Worker は entries をそのまま JSON 化して S3 へ PUT するので、フロント側で entry にフィールドを足すだけで記録できる（Worker は変更不要）。
+- **flush の挙動**: 表示中 entry は dwell_ms 未確定のため flush 対象外。切替・離脱で確定してから送られる。
+- **Plan I と Few-shot の相性**: 抜粋を唯一の情報源にする方針に 👍 例文の Few-shot を混ぜると抜粋外表現を誘発し忠実性を崩すため不採用。

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -608,6 +608,21 @@ Issue #46 の opacity 0.3 は控えめという実機フィードバックを受
 - [ ] **陰影が見えない問題を修正**: Standard の不透明な地面の下（slot:'bottom'）に hillshade を敷いたため隠れている疑い。`setTerrain`（本物の3D地形、exaggeration を off/弱/強に割当）方式へ切替え、昼に検証
 - [ ] PR 作成・マージ（保留 or 先行は要相談）
 
+## Issue #17 👍/👎 明示フィードバックボタン（2026-06-07）
+
+「土地のたより」カードに 👍/👎 を追加し、表示中 entry の `user_rating` をテレメトリに記録（集計用途のみ、Few-shot 経路 #18 は不採用）。詳細は knowledge.md 7 章。
+
+- [x] index.html: カード右下に 👍/👎 ボタン（48×48 タップ領域、初期 hidden）
+- [x] app.css: `.tayori-rating` / `.rating-btn`（active で 👍 緑 / 👎 赤の薄背景）
+- [x] telemetry.js: `nextRating(current, clicked)` 純粋関数（同ボタン再タップで null）
+- [x] ui.js: `setRatingState` / `showRating` / `hideRating`
+- [x] app.js: クリックで `updateTelemetry(traceId, {user_rating})`、切替時リセット、解説確定時に表示
+- [x] Vitest: nextRating 6件 + setRatingState/show/hide 5件（全 140 件 pass）
+- [x] E2E: rating 表示・トグル・localStorage 記録の検証（本番反映後に流す）
+- [ ] PR 作成・マージ・本番反映
+- [ ] 本番反映後に E2E 実行（`source ~/.secrets/trip-road.env && npm run test:e2e`）→ スクショ確認
+- [ ] Athena で `user_rating` がクエリできることを確認（データ蓄積後）
+
 ### さらに先（無時系列、検討候補）
 
 - [ ] Service Worker によるオフライン対応

--- a/public/assets/app.css
+++ b/public/assets/app.css
@@ -390,6 +390,34 @@ body {
 .hillshade-toggle.hillshade-weak { opacity: 0.7; }
 .hillshade-toggle.hillshade-strong { opacity: 1; }
 
+/* Issue #17: 👍 / 👎 明示フィードバックボタン。カード右下に控えめに置く */
+.tayori-rating {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-top: 8px;
+}
+.rating-btn {
+  /* 押しやすい 48x48 のタップ領域を確保しつつ、絵文字自体は小さく見せる */
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  background: transparent;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  opacity: 0.4;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 150ms, background 150ms, transform 100ms;
+}
+.rating-btn:active { transform: scale(0.88); }
+.rating-btn.rating-active { opacity: 1; }
+#rating-up.rating-active { background: rgba(80, 200, 120, 0.18); }
+#rating-down.rating-active { background: rgba(230, 100, 100, 0.18); }
+
 /* Plan E (6.5b): デバッグオーバーレイ。description のすぐ下に出す */
 .debug-info {
   margin-top: 10px;

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -32,7 +32,7 @@ import { initMap, updateCurrentLocation, addTrackPoint, setTrack, clearTrack, se
 import { filterTodayPoints, isSameLocalDay } from './track_filter.js';
 import { startWatching } from './geo.js';
 import { fetchElevation, createElevationUpdater } from './elevation.js';
-import { generateTraceId, buildTelemetryEntry, shouldSample } from './telemetry.js';
+import { generateTraceId, buildTelemetryEntry, shouldSample, nextRating } from './telemetry.js';
 import { shouldEnterSwitchFlow } from './switch_flow.js';
 import {
   showPasswordScreen, showMainScreen,
@@ -43,6 +43,7 @@ import {
   setDescriptionNoWikipedia, clearDescription,
   setGpsActive, setPermissionDenied,
   setDebugInfo,
+  setRatingState, showRating, hideRating,
 } from './ui.js';
 
 let currentMuniCd = null;
@@ -70,6 +71,9 @@ let currentJudgeData = null;
 const TELEMETRY_SAMPLE_RATE = 1.0;  // 初期 100%、運用で 0.1〜0.2 に下げる
 let currentTraceId = null;
 let currentDisplayStartMs = null;
+// Issue #17: 表示中カードの 👍 / 👎 状態（'up' / 'down' / null）。
+// 市町村切替で新しい trace_id を発行するたびに null へリセットする。
+let currentRating = null;
 
 // === テレメトリ自動 flush 設定 ===
 // 市町村切替のたびに、確定した直前 entry を即 S3 へ送信する。
@@ -188,6 +192,16 @@ async function enterMainApp(password) {
       applyHillshadeLayer(next);
       setHillshadeToggleState(next);
     });
+  }
+
+  // Issue #17: 👍 / 👎 明示フィードバックボタン。
+  // 表示中カードの trace_id の entry に user_rating を記録する。
+  // 同じボタン再タップで取り消し（null）。flush は既存経路（切替/60秒タイマー）に任せる。
+  const ratingUpBtn = document.getElementById('rating-up');
+  const ratingDownBtn = document.getElementById('rating-down');
+  if (ratingUpBtn && ratingDownBtn) {
+    ratingUpBtn.addEventListener('click', () => handleRatingClick('up'));
+    ratingDownBtn.addEventListener('click', () => handleRatingClick('down'));
   }
 
   // 標高更新（Issue #46）。GPS coords.altitude が取れればそれを使い、
@@ -335,6 +349,12 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
     currentTraceId = sampled ? generateTraceId() : null;
     currentDisplayStartMs = null;
 
+    // Issue #17: 新カードに切り替わったので 👍 / 👎 をリセットして一旦隠す。
+    // 解説が確定した時点（キャッシュ/生成成功）で showRating() する。
+    currentRating = null;
+    setRatingState(null);
+    hideRating();
+
     tryFlushTelemetry(password);
 
     if (cached) {
@@ -350,6 +370,7 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
         }));
         currentDisplayStartMs = Date.now();
         updateTelemetry(currentTraceId, { ts_displayed: currentDisplayStartMs });
+        showRating();  // Issue #17: 有効な解説が出たので 👍 / 👎 を表示
       }
     } else {
       setDescriptionLoading();
@@ -425,6 +446,7 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
             }));
             currentDisplayStartMs = Date.now();
             updateTelemetry(currentTraceId, { ts_displayed: currentDisplayStartMs });
+            showRating();  // Issue #17: 有効な解説が出たので 👍 / 👎 を表示
           }
         }
       } else if (result.status === 401) {
@@ -449,6 +471,17 @@ function finalizeCurrentTelemetry() {
       dwell_ms: ts_left - currentDisplayStartMs,
     });
   }
+}
+
+// === Issue #17: 👍 / 👎 クリック処理 ===
+// 表示中 entry の user_rating を更新する。trace_id が無い（サンプリング外）ときは無視。
+// 同じボタン再タップで null（取り消し）に戻す。updateTelemetry で localStorage に反映し、
+// flush は既存の自動経路（市町村切替・60 秒タイマー）に任せる。
+function handleRatingClick(clicked) {
+  if (!currentTraceId) return;
+  currentRating = nextRating(currentRating, clicked);
+  updateTelemetry(currentTraceId, { user_rating: currentRating });
+  setRatingState(currentRating);
 }
 
 // === GPS エラー処理 ===

--- a/public/assets/telemetry.js
+++ b/public/assets/telemetry.js
@@ -85,6 +85,18 @@ export function buildTelemetryEntry(args) {
 }
 
 /**
+ * Issue #17: 👍 / 👎 のトグル遷移を決める純粋関数。
+ * 同じボタンを再タップしたら null（取り消し）に戻し、別のボタンなら切り替える。
+ *
+ * @param {'up'|'down'|null} current - 現在の user_rating
+ * @param {'up'|'down'} clicked - 押されたボタン
+ * @returns {'up'|'down'|null} 次の user_rating
+ */
+export function nextRating(current, clicked) {
+  return current === clicked ? null : clicked;
+}
+
+/**
  * サンプリング判定。
  *
  * @param {number} sampleRate - 0.0 〜 1.0

--- a/public/assets/ui.js
+++ b/public/assets/ui.js
@@ -47,6 +47,27 @@ export function setVisitedCount(n) {
   $('visited-count').textContent = String(n);
 }
 
+// === Issue #17: 👍 / 👎 明示フィードバック ===
+// ボタンの選択状態（'up' / 'down' / null）を DOM に反映する。
+export function setRatingState(rating) {
+  const up = $('rating-up');
+  const down = $('rating-down');
+  if (!up || !down) return;
+  up.classList.toggle('rating-active', rating === 'up');
+  up.setAttribute('aria-pressed', String(rating === 'up'));
+  down.classList.toggle('rating-active', rating === 'down');
+  down.setAttribute('aria-pressed', String(rating === 'down'));
+}
+// 有効な解説が表示されているときだけ rating 行を出す。
+export function showRating() {
+  const el = $('tayori-rating');
+  if (el) el.classList.remove('hidden');
+}
+export function hideRating() {
+  const el = $('tayori-rating');
+  if (el) el.classList.add('hidden');
+}
+
 export function setDescription(text) {
   const body = $('description');
   const skel = $('description-skeleton');

--- a/public/index.html
+++ b/public/index.html
@@ -82,6 +82,11 @@
         <div></div><div></div><div class="short"></div>
       </div>
       <div id="description-loading-text" class="tayori-loading-text hidden"></div>
+      <!-- Issue #17: 👍 / 👎 明示フィードバック。解説が出ているときだけ表示する -->
+      <div id="tayori-rating" class="tayori-rating hidden">
+        <button type="button" id="rating-up" class="rating-btn" aria-label="この解説はよかった" aria-pressed="false">👍</button>
+        <button type="button" id="rating-down" class="rating-btn" aria-label="この解説はいまいち" aria-pressed="false">👎</button>
+      </div>
       <pre id="debug-info" class="debug-info hidden"></pre>
     </div>
 

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -3,6 +3,7 @@ import {
   generateTraceId,
   buildTelemetryEntry,
   shouldSample,
+  nextRating,
 } from '../public/assets/telemetry.js';
 
 describe('generateTraceId', () => {
@@ -117,6 +118,27 @@ describe('buildTelemetryEntry (Plan I)', () => {
     expect(entry.fallback_to_extract).toBe(true);
     expect(entry.regenerated).toBe(true);
     expect(entry.faithfulness_score).toBe(2);
+  });
+});
+
+describe('nextRating (Issue #17 トグル)', () => {
+  it('未評価のカードで 👍 を押すと up になる', () => {
+    expect(nextRating(null, 'up')).toBe('up');
+  });
+  it('未評価のカードで 👎 を押すと down になる', () => {
+    expect(nextRating(null, 'down')).toBe('down');
+  });
+  it('既に up のカードで同じ 👍 を押すと取り消されて null に戻る', () => {
+    expect(nextRating('up', 'up')).toBeNull();
+  });
+  it('既に down のカードで同じ 👎 を押すと取り消されて null に戻る', () => {
+    expect(nextRating('down', 'down')).toBeNull();
+  });
+  it('up のカードで 👎 を押すと down に切り替わる', () => {
+    expect(nextRating('up', 'down')).toBe('down');
+  });
+  it('down のカードで 👍 を押すと up に切り替わる', () => {
+    expect(nextRating('down', 'up')).toBe('up');
   });
 });
 

--- a/test/ui_dom.test.js
+++ b/test/ui_dom.test.js
@@ -14,6 +14,9 @@ import {
     setDescriptionLoadingPhase,
     setElevation,
     setHillshadeToggleState,
+    setRatingState,
+    showRating,
+    hideRating,
 } from '../public/assets/ui.js';
 
 function makeEl() {
@@ -47,13 +50,19 @@ beforeEach(() => {
         'description-loading-text': makeEl(),
         elevation: makeEl(),
         'hillshade-toggle': makeEl(),
+        'tayori-rating': makeEl(),
+        'rating-up': makeEl(),
+        'rating-down': makeEl(),
     };
-    // hillshade-toggle に最小限の属性 API を追加
-    els['hillshade-toggle'].attrs = {};
-    els['hillshade-toggle'].setAttribute = function (k, v) { this.attrs[k] = v; };
-    els['hillshade-toggle'].getAttribute = function (k) { return this.attrs[k] ?? null; };
+    // setAttribute / getAttribute を使う要素に最小限の属性 API を足す
+    for (const id of ['hillshade-toggle', 'rating-up', 'rating-down']) {
+        els[id].attrs = {};
+        els[id].setAttribute = function (k, v) { this.attrs[k] = v; };
+        els[id].getAttribute = function (k) { return this.attrs[k] ?? null; };
+    }
     els['description-skeleton'].classList.add('hidden');
     els['description-loading-text'].classList.add('hidden');
+    els['tayori-rating'].classList.add('hidden');
     globalThis.document = {
         getElementById: (id) => els[id] ?? null,
     };
@@ -143,6 +152,41 @@ describe('setElevation (Issue #46)', () => {
     it('undefined も "--" 表示', () => {
         setElevation(undefined);
         expect(els.elevation.textContent).toBe('--');
+    });
+});
+
+describe('setRatingState (Issue #17)', () => {
+    it("'up' で 👍 に rating-active と aria-pressed=true が付き、👎 は付かない", () => {
+        setRatingState('up');
+        expect(els['rating-up'].classList.contains('rating-active')).toBe(true);
+        expect(els['rating-up'].getAttribute('aria-pressed')).toBe('true');
+        expect(els['rating-down'].classList.contains('rating-active')).toBe(false);
+        expect(els['rating-down'].getAttribute('aria-pressed')).toBe('false');
+    });
+    it("'down' で 👎 だけ rating-active になる", () => {
+        setRatingState('down');
+        expect(els['rating-down'].classList.contains('rating-active')).toBe(true);
+        expect(els['rating-up'].classList.contains('rating-active')).toBe(false);
+    });
+    it('null で両方の rating-active が外れ aria-pressed=false に戻る', () => {
+        setRatingState('up');
+        setRatingState(null);
+        expect(els['rating-up'].classList.contains('rating-active')).toBe(false);
+        expect(els['rating-down'].classList.contains('rating-active')).toBe(false);
+        expect(els['rating-up'].getAttribute('aria-pressed')).toBe('false');
+        expect(els['rating-down'].getAttribute('aria-pressed')).toBe('false');
+    });
+});
+
+describe('showRating / hideRating (Issue #17)', () => {
+    it('showRating で hidden が外れる', () => {
+        showRating();
+        expect(els['tayori-rating'].classList.contains('hidden')).toBe(false);
+    });
+    it('hideRating で hidden が付く', () => {
+        showRating();
+        hideRating();
+        expect(els['tayori-rating'].classList.contains('hidden')).toBe(true);
     });
 });
 

--- a/tests/e2e/main.spec.js
+++ b/tests/e2e/main.spec.js
@@ -66,6 +66,44 @@ test.describe('trip-road メイン画面 E2E', () => {
     expect(criticalErrors).toEqual([]);
   });
 
+  test('5. 解説表示後に 👍/👎 が出てトグル記録できる（Issue #17）', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('#password-input').fill(APP_PASSWORD);
+    await page.locator('#password-submit').click();
+    await expect(page.locator('#main-screen')).toBeVisible();
+
+    // 解説が確定する（skeleton が消える）と rating 行が表示される
+    await expect(page.locator('#description-skeleton')).toBeHidden({ timeout: 30000 });
+    const rating = page.locator('#tayori-rating');
+    await expect(rating).toBeVisible();
+
+    const up = page.locator('#rating-up');
+    const down = page.locator('#rating-down');
+
+    // 初期は未選択
+    await expect(up).toHaveAttribute('aria-pressed', 'false');
+    await expect(down).toHaveAttribute('aria-pressed', 'false');
+
+    // 👍 を押すと up だけが選択状態になる
+    await up.click();
+    await expect(up).toHaveAttribute('aria-pressed', 'true');
+    await expect(down).toHaveAttribute('aria-pressed', 'false');
+
+    // localStorage の telemetry に user_rating='up' が記録される
+    const recorded = await page.evaluate(() => {
+      const s = JSON.parse(localStorage.getItem('trip-road-state') || '{}');
+      const rated = (s.telemetry || []).filter((e) => e.user_rating != null);
+      return rated.length ? rated[rated.length - 1].user_rating : null;
+    });
+    expect(recorded).toBe('up');
+
+    // 同じ 👍 を再タップすると取り消されて未選択に戻る
+    await up.click();
+    await expect(up).toHaveAttribute('aria-pressed', 'false');
+
+    await page.screenshot({ path: 'tests/e2e/results/05-rating.png' });
+  });
+
   test('4. visibilitychange 後も地図サイズが正しく保たれる（バグ修正検証）', async ({ page }) => {
     await page.goto('/');
     await page.locator('#password-input').fill(APP_PASSWORD);


### PR DESCRIPTION
## 概要

「土地のたより」カードに 👍 / 👎 ボタンを追加し、表示中 entry の `user_rating`（'up'/'down'/null）をテレメトリに記録する。Issue #17。

用途は **集計のみ**（Athena で `WHERE user_rating='down'` を抽出し Plan I が苦手な市町村を特定）。Few-shot 学習素材経路（#18）は Plan I の in-context 要約特化と相性が悪いため不採用。

## 変更点

- **index.html**: カード右下に 👍/👎（48×48 タップ領域、初期 hidden）
- **app.css**: `.tayori-rating` / `.rating-btn`（active で 👍 緑・👎 赤の薄背景）
- **telemetry.js**: `nextRating(current, clicked)` 純粋関数（同ボタン再タップで null 取り消し）
- **ui.js**: `setRatingState` / `showRating` / `hideRating`
- **app.js**: クリックで `updateTelemetry(traceId, {user_rating})`、市町村切替時にリセット、解説確定時に表示
- **Worker は変更なし**: `/api/telemetry` は entries をそのまま JSON 化して S3 PUT するため、entry にフィールドを足すだけで永続化される（`user_rating` の器は Plan D Stage 1 で用意済）

## 設計判断

- flush は既存経路（市町村切替・60秒タイマー）に委譲。表示中 entry は dwell_ms 未確定で flush 対象外のため、評価しても即送信されないのは仕様通り。
- カードに有効な解説が出ているときだけ rating を表示（ローディング・記事なし・失敗時は隠す）。

## テスト

- Vitest: `nextRating` 6件 + `setRatingState`/`showRating`/`hideRating` 5件を追加。**全 140 件 pass**。
- E2E: rating 表示・トグル・localStorage 記録を検証する spec を追加（baseURL が本番のため、**マージ・本番反映後に実行**して視覚確認する）。

## 残作業（マージ後）

- 本番反映 → `source ~/.secrets/trip-road.env && npm run test:e2e` でスクショ確認
- データ蓄積後に Athena で `user_rating` がクエリできることを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)