### PR TITLE
fix: メイン画面初期化の競合を解消（rating 表示分離・フッター配線前倒し）

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -2115,3 +2115,11 @@ VSCode アップデートで中断した #71（nova.js プロンプト改善）�
 - **デプロイ直後は誰の説明文も変わらない**: Worker をデプロイしても即時には文章は変化しない。フロントの `DESCRIPTION_VERSION=2` と localStorage の版数が不一致の市町村を次に訪問した時、Worker へ再生成要求が飛んで初めて新プロンプトの文章が出る。
 - **課金は再生成ごとの Bedrock Nova トークン**: 版数不一致の市町村を再訪するたびに Generator(Nova) の入出力トークン課金が1回発生。Wikipedia/Wikidata の元データは Worker 側 Cache API が効くので二重課金しない。
 - **ロールバックは wrangler**: `wrangler rollback` / `wrangler versions deploy` で直前バージョンに即戻せる。コードは git にあるので revert→再 deploy でも可。不可逆操作ではない。
+
+### 学習済み概念（フロント本番デプロイ軸、理解度テスト 2026-06-07 全問正解）
+
+`fix/main-screen-init-races`（rating 表示分離・フッター配線前倒し）のフロント Pages デプロイ前に実施。
+
+- **デプロイで変わる UX**: rating が sampling と無関係に常時表示、画面表示直後の 🗺️ タップが無反応にならない（フッター配線が Mapbox トークン取得待ちより前になった）。
+- **「評価を常に記録」のコスト影響**: 未サンプル時に 👍/👎 を押したときだけ trace を遅延発行し 1 エントリ分の S3 書込が微増。評価はレアな明示操作なので微量。Nova 課金は生成を伴わないため発生しない。
+- **フロントのロールバック**: Cloudflare Pages は過去デプロイメントへロールバック可能。コードは git にあるので revert→`deploy_frontend.sh` 再実行でも戻せる。不可逆ではない。

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -2107,3 +2107,11 @@ iPhone Safari メモリ予算（~1 GB）内に十分収まる。Cloudflare Pages
 - **テレメトリ記録の仕組み**: Worker は entries をそのまま JSON 化して S3 へ PUT するので、フロント側で entry にフィールドを足すだけで記録できる（Worker は変更不要）。
 - **flush の挙動**: 表示中 entry は dwell_ms 未確定のため flush 対象外。切替・離脱で確定してから送られる。
 - **Plan I と Few-shot の相性**: 抜粋を唯一の情報源にする方針に 👍 例文の Few-shot を混ぜると抜粋外表現を誘発し忠実性を崩すため不採用。
+
+### 学習済み概念（本番デプロイ軸、理解度テスト 2026-06-07 全問正解）
+
+VSCode アップデートで中断した #71（nova.js プロンプト改善）の本番 Worker デプロイ前に実施。以降この3点は同種デプロイ時スキップ可。
+
+- **デプロイ直後は誰の説明文も変わらない**: Worker をデプロイしても即時には文章は変化しない。フロントの `DESCRIPTION_VERSION=2` と localStorage の版数が不一致の市町村を次に訪問した時、Worker へ再生成要求が飛んで初めて新プロンプトの文章が出る。
+- **課金は再生成ごとの Bedrock Nova トークン**: 版数不一致の市町村を再訪するたびに Generator(Nova) の入出力トークン課金が1回発生。Wikipedia/Wikidata の元データは Worker 側 Cache API が効くので二重課金しない。
+- **ロールバックは wrangler**: `wrangler rollback` / `wrangler versions deploy` で直前バージョンに即戻せる。コードは git にあるので revert→再 deploy でも可。不可逆操作ではない。

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -619,9 +619,38 @@ Issue #46 の opacity 0.3 は控えめという実機フィードバックを受
 - [x] app.js: クリックで `updateTelemetry(traceId, {user_rating})`、切替時リセット、解説確定時に表示
 - [x] Vitest: nextRating 6件 + setRatingState/show/hide 5件（全 140 件 pass）
 - [x] E2E: rating 表示・トグル・localStorage 記録の検証（本番反映後に流す）
-- [ ] PR 作成・マージ・本番反映
-- [ ] 本番反映後に E2E 実行（`source ~/.secrets/trip-road.env && npm run test:e2e`）→ スクショ確認
+- [x] PR 作成・マージ・本番反映（フロントは #72 デプロイ済、rating ボタン本番反映確認）
+- [~] 本番反映後に E2E 実行（`set -a && source ~/.secrets/trip-road.env && set +a && npm run test:e2e`）→ rating 機能は本番で正常動作を実測確認。ただし E2E test#5 は GPS 確定待ち不足で際どく失敗（テスト側の不備、後述）
 - [ ] Athena で `user_rating` がクエリできることを確認（データ蓄積後）
+
+### E2E 課題への対応状況（2026-06-07、ブランチ `fix/main-screen-init-races`）
+
+Codex はモデルエラーで使用不可だったため Claude Code 単独で実装（フォールバック）。
+
+- [x] **修正1 fix(rating)**: `app.js` の `showRating()` を `if (currentTraceId)` の外へ出し、有効説明文時は sampling と無関係に常時表示。`handleRatingClick` は trace 無しなら遅延発行して必ず記録（受動テレメトリのみ sampling）。判断を純粋関数 `planRatingClick`（telemetry.js）に切り出し、起動時キャッシュ表示経路でも rating 表示
+- [x] **修正2 fix(map)**: フッターボタン（⚙️/⛰️/👍👎/🗺️）のリスナ装着を `await getMapboxToken()` より前へ。地図依存の hillshade 初期適用のみ initMap 後に残す。約375msの未配線ウィンドウを解消
+- [x] **修正3 test(e2e)**: main.spec test#5 に `muni-name` 確定待ち + rating timeout 10s、history.spec `enterHistoryScreen` に `waitForResponse('/api/mapbox-token')`
+- [x] Vitest 145件 pass（planRatingClick 5件追加）
+- [ ] フロント本番デプロイ（`deploy_frontend.sh`）→ 本番 E2E 再実行で rating/history 緑化を確認
+- [ ] PR 作成・マージ
+
+### E2E 実行で判明した課題（2026-06-07、要対応）
+
+VSCode 中断分の続きで本番 E2E（39件、chromium-iphone / desktop-chromium / webkit-iphone × 各テスト）を実行した結果：
+
+- **rating test#5 はテスト側の不備（実害なし）**: 実測で `/api/describe` 1回・rating は t=5.0s で表示・説明文も新プロンプトで正常生成（久喜市の鷲宮砂丘が核）。test#3 は `muni-name` が「現在地を取得中...」から変わるのを待つが、**test#5 はこの GPS 確定待ちを省略**。skeleton は起動直後（ロード前）も `hidden` のため待機が即通過し、GPS 確定前に rating を 5s で確認して失敗。→ test#5 に muni-name 同期を足すか toBeVisible の timeout を伸ばす
+- **潜在バグ: rating 表示がテレメトリ sampling に結合**: `app.js` の `showRating()` は `if (currentTraceId)` 内のみ。現状 `TELEMETRY_SAMPLE_RATE=1.0` なので常に表示されるが、運用で 0.1〜0.2 に下げると 👍/👎 が 80〜90% のセッションで出なくなる。表示と記録を分離する（表示は常時、記録のみ sampling 判定）必要あり
+- **webkit-iphone 全滅は環境起因**: `browserType.launch` 失敗＝WebKit 未インストール。`sudo npx playwright install-deps webkit` 1回で解消（実バグではない）
+- **history.spec.js 全滅（chromium/desktop 両方）= Mapbox 移行起因の配線競合（履歴機能自体は正常）**: 調査の結果、`#history-open`（🗺️）は `showMainScreen()`（app.js 121行）で即可視になるが、click リスナ装着は `await getMapboxToken()`（125行・約145ms）を挟んだ後の 222〜229行。可視〜配線の間に**約375msの「リスナ未装着ウィンドウ」**があり、テストはこの隙にクリック→`<a href="#">`が無反応→`#history-screen` が hidden のままタイムアウト。CDP 実測で「即時クリック=FAIL／1秒待機=PASS／occlusion ではない」を確認。`/api/conquests`・geojson・DynamoDB 同期はすべて 200。Leaflet 時代はトークン取得が無く配線がほぼ同期だったため顕在化しなかった。
+  - 対応: **(本番コード)** フッターボタンのリスナ装着を `await getMapboxToken()` より前（`showMainScreen()` 直後）に移す。実機の遅い回線でも表示直後の 🗺️ タップが無反応になる UX 問題も同時に解消。**(テスト)** `enterHistoryScreen` でクリック前に `waitForResponse('**/api/mapbox-token')` か、クリックを `toPass` でリトライ
+
+### #71 たより事実核型改善の本番 Worker デプロイ（2026-06-07、VSCode 中断分の続き）
+
+`nova.js` の Generator プロンプト改善（固有事実核型・羅列禁止・名物/由来優先）と `DESCRIPTION_VERSION=2` を本番反映。中断時はコミット済・フロントのみデプロイ済で Worker 未反映だった。
+
+- [x] Worker 本番デプロイ（`bash deploy_production.sh`、Version ID `e30833e0`）
+- [x] 本番 curl 検証：鎌倉市 200 / judge_passed:true / faithfulness 5 / nova-pro、認証失敗 401、別パス 404
+- [x] 理解度テスト（本番デプロイ軸）全問正解 → knowledge.md「学習済み概念」に追記
 
 ### さらに先（無時系列、検討候補）
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -633,10 +633,11 @@ Codex はモデルエラーで使用不可だったため Claude Code 単独で�
 - [x] Vitest 145件 pass（planRatingClick 5件追加）
 - [x] フロント本番デプロイ（`deploy_frontend.sh`、Deployment `1d3e1147`）→ 本番アセットに planRatingClick・配線前倒し反映を確認
 - [x] 本番 E2E 再実行（main+history × chromium 系2プロジェクト、16 passed / 2 failed）。**rating test#5 と history ナビゲーション系は緑化**を確認
-- [ ] PR 作成・マージ
-- 残2件はスコープ外の既存問題:
-  - `history.spec.js` diag（desktop-chromium のみ）: `touchscreen.tap` は hasTouch 必須で desktop 無効 → diag テストを touch 有効プロジェクト限定に skip すべき（テスト設定。iphone-emulated は PASS）
-  - `main.spec.js` test#4 visibilitychange 地図サイズ: Mapbox `map.resize()` 系の別件（要個別調査）
+- [x] history diag を touch 有効プロジェクト限定に skip（コミット ca6f401）→ history 7 passed / 1 skipped / 0 failed
+- [x] PR 作成（**#74**）。マージはてつてつ判断
+- 残課題:
+  - [x] `history.spec.js` diag（desktop-chromium のみ）: touch 限定 skip で解消
+  - [ ] `main.spec.js` test#4 visibilitychange 地図サイズ: Mapbox の別件として **#73** を起票（本PR対象外）
 
 ### E2E 実行で判明した課題（2026-06-07、要対応）
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -631,8 +631,12 @@ Codex はモデルエラーで使用不可だったため Claude Code 単独で�
 - [x] **修正2 fix(map)**: フッターボタン（⚙️/⛰️/👍👎/🗺️）のリスナ装着を `await getMapboxToken()` より前へ。地図依存の hillshade 初期適用のみ initMap 後に残す。約375msの未配線ウィンドウを解消
 - [x] **修正3 test(e2e)**: main.spec test#5 に `muni-name` 確定待ち + rating timeout 10s、history.spec `enterHistoryScreen` に `waitForResponse('/api/mapbox-token')`
 - [x] Vitest 145件 pass（planRatingClick 5件追加）
-- [ ] フロント本番デプロイ（`deploy_frontend.sh`）→ 本番 E2E 再実行で rating/history 緑化を確認
+- [x] フロント本番デプロイ（`deploy_frontend.sh`、Deployment `1d3e1147`）→ 本番アセットに planRatingClick・配線前倒し反映を確認
+- [x] 本番 E2E 再実行（main+history × chromium 系2プロジェクト、16 passed / 2 failed）。**rating test#5 と history ナビゲーション系は緑化**を確認
 - [ ] PR 作成・マージ
+- 残2件はスコープ外の既存問題:
+  - `history.spec.js` diag（desktop-chromium のみ）: `touchscreen.tap` は hasTouch 必須で desktop 無効 → diag テストを touch 有効プロジェクト限定に skip すべき（テスト設定。iphone-emulated は PASS）
+  - `main.spec.js` test#4 visibilitychange 地図サイズ: Mapbox `map.resize()` 系の別件（要個別調査）
 
 ### E2E 実行で判明した課題（2026-06-07、要対応）
 

--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -32,7 +32,7 @@ import { initMap, updateCurrentLocation, addTrackPoint, setTrack, clearTrack, se
 import { filterTodayPoints, isSameLocalDay } from './track_filter.js';
 import { startWatching } from './geo.js';
 import { fetchElevation, createElevationUpdater } from './elevation.js';
-import { generateTraceId, buildTelemetryEntry, shouldSample, nextRating } from './telemetry.js';
+import { generateTraceId, buildTelemetryEntry, shouldSample, planRatingClick } from './telemetry.js';
 import { shouldEnterSwitchFlow } from './switch_flow.js';
 import {
   showPasswordScreen, showMainScreen,
@@ -74,6 +74,11 @@ let currentDisplayStartMs = null;
 // Issue #17: 表示中カードの 👍 / 👎 状態（'up' / 'down' / null）。
 // 市町村切替で新しい trace_id を発行するたびに null へリセットする。
 let currentRating = null;
+// Issue #17: 現在表示中の有効な説明文。サンプリングの有無に関わらず保持する。
+// 👍 / 👎 がサンプリング外セッションで押されたとき、この muni_code / 本文を使って
+// テレメトリエントリを遅延発行し、評価を必ず記録するために使う。null のときは
+// 有効な説明文が出ていない（記事なし・生成失敗・切替直後）状態を表す。
+let currentDescriptionText = null;
 
 // === テレメトリ自動 flush 設定 ===
 // 市町村切替のたびに、確定した直前 entry を即 S3 へ送信する。
@@ -119,42 +124,12 @@ function setupPasswordScreen() {
 // === メイン画面初期化 ===
 async function enterMainApp(password) {
   showMainScreen();
-  // Mapbox トークンを Worker から取得してから地図を初期化する。
-  // 取得失敗時は地図初期化をスキップし、アプリ全体はクラッシュさせない
-  // （現在地チップや土地のたよりなど地図以外の機能は引き続き動く）。
-  const tokenResult = await getMapboxToken(password);
-  if (tokenResult.ok) {
-    initMap('map', tokenResult.token);
-  } else {
-    console.warn('[app] Mapbox トークン取得に失敗、地図初期化をスキップ', tokenResult);
-  }
-  setVisitedCount(getVisitedCount());
 
-  // 既存軌跡を復元（今日の ts のものだけ描画。過去日分は localStorage に温存）
-  const state = loadState();
-  const todayPoints = filterTodayPoints(state.track, Date.now());
-  if (todayPoints.length > 0) {
-    setTrack(todayPoints);
-    lastTrackTs = todayPoints[todayPoints.length - 1].ts;
-  }
-
-  // 既存の現在地情報を表示（キャッシュ済要約があれば）
-  if (currentMuniCd && state.visited[currentMuniCd]) {
-    const v = state.visited[currentMuniCd];
-    setMuniName(v.name);
-    const cached = getCachedDescription(currentMuniCd);
-    if (cached) {
-      setDescription(cached);
-      currentJudgeData = { cached: true };
-      setDebugInfo(currentJudgeData, isDebugOn());
-    }
-  }
-
-  // GPS 監視開始
-  startWatching(
-    (pos) => handlePosition(pos, password),
-    (err) => handleGpsError(err),
-  );
+  // --- フッターボタン等のイベント配線を Mapbox トークン取得（await）より前に済ませる ---
+  // showMainScreen() でフッターボタンは即可視になる。一方 getMapboxToken() は
+  // ネットワーク待ちを伴うため、配線を await の後に置くと「ボタンは見えるが
+  // リスナ未装着」の数百ms の窓が生じ、その間のタップが無反応になる
+  // （Mapbox 移行で顕在化。実機の遅い回線でも同様の UX 不具合）。配線を先に出す。
 
   // 画面離脱時（タブ閉じ・最小化）に dwell_ms を確定
   window.addEventListener('beforeunload', finalizeCurrentTelemetry);
@@ -177,12 +152,10 @@ async function enterMainApp(password) {
   }
 
   // 陰影起伏図トグル（⛰️ ボタン）。Issue #48 で off → weak → strong → off の 3 段階循環に。
+  // click リスナはここで装着し、地図に依存する初期レイヤ適用は initMap 後に行う。
   const hillshadeBtn = document.getElementById('hillshade-toggle');
   if (hillshadeBtn) {
     const HILLSHADE_CYCLE = ['off', 'weak', 'strong'];
-    const initial = getHillshadeLevel();
-    applyHillshadeLayer(initial);
-    setHillshadeToggleState(initial);
     hillshadeBtn.addEventListener('click', (e) => {
       e.preventDefault();
       const cur = getHillshadeLevel();
@@ -195,8 +168,8 @@ async function enterMainApp(password) {
   }
 
   // Issue #17: 👍 / 👎 明示フィードバックボタン。
-  // 表示中カードの trace_id の entry に user_rating を記録する。
-  // 同じボタン再タップで取り消し（null）。flush は既存経路（切替/60秒タイマー）に任せる。
+  // 表示中カードに user_rating を記録する。サンプリング外でも handleRatingClick が
+  // trace を遅延発行して必ず記録する。同じボタン再タップで取り消し（null）。
   const ratingUpBtn = document.getElementById('rating-up');
   const ratingDownBtn = document.getElementById('rating-down');
   if (ratingUpBtn && ratingDownBtn) {
@@ -218,7 +191,7 @@ async function enterMainApp(password) {
     }
   }, TELEMETRY_FLUSH_INTERVAL_MS);
 
-  // 踏破履歴画面（Phase 13）: 🗺️ ボタンで開く + 起動時に未同期分を flush
+  // 踏破履歴画面（Phase 13）: 🗺️ ボタンで開く
   setupHistoryScreen();
   const historyBtn = document.getElementById('history-open');
   if (historyBtn) {
@@ -227,6 +200,59 @@ async function enterMainApp(password) {
       openHistoryScreen();
     });
   }
+
+  // --- ここから地図初期化（ネットワーク待ちを含む） ---
+  // Mapbox トークンを Worker から取得してから地図を初期化する。
+  // 取得失敗時は地図初期化をスキップし、アプリ全体はクラッシュさせない
+  // （現在地チップや土地のたよりなど地図以外の機能は引き続き動く）。
+  const tokenResult = await getMapboxToken(password);
+  if (tokenResult.ok) {
+    initMap('map', tokenResult.token);
+  } else {
+    console.warn('[app] Mapbox トークン取得に失敗、地図初期化をスキップ', tokenResult);
+  }
+
+  // 地図に依存する陰影起伏図の初期レイヤ適用（initMap 後に実施）
+  if (hillshadeBtn) {
+    const hillshadeInitial = getHillshadeLevel();
+    applyHillshadeLayer(hillshadeInitial);
+    setHillshadeToggleState(hillshadeInitial);
+  }
+
+  setVisitedCount(getVisitedCount());
+
+  // 既存軌跡を復元（今日の ts のものだけ描画。過去日分は localStorage に温存）
+  const state = loadState();
+  const todayPoints = filterTodayPoints(state.track, Date.now());
+  if (todayPoints.length > 0) {
+    setTrack(todayPoints);
+    lastTrackTs = todayPoints[todayPoints.length - 1].ts;
+  }
+
+  // 既存の現在地情報を表示（キャッシュ済要約があれば）
+  if (currentMuniCd && state.visited[currentMuniCd]) {
+    const v = state.visited[currentMuniCd];
+    setMuniName(v.name);
+    const cached = getCachedDescription(currentMuniCd);
+    if (cached) {
+      setDescription(cached);
+      currentDescriptionText = cached;
+      currentJudgeData = { cached: true };
+      setDebugInfo(currentJudgeData, isDebugOn());
+      // Issue #17: 起動時のキャッシュ表示でも 👍 / 👎 を出す。
+      // この経路は sampling 判定前なので trace は無いが、クリック時に遅延記録される。
+      currentRating = null;
+      setRatingState(null);
+      showRating();
+    }
+  }
+
+  // GPS 監視開始
+  startWatching(
+    (pos) => handlePosition(pos, password),
+    (err) => handleGpsError(err),
+  );
+
   // バックグラウンドで前日以前の visited を DynamoDB に flush
   tryFlushConquests(password);
 }
@@ -351,7 +377,10 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
 
     // Issue #17: 新カードに切り替わったので 👍 / 👎 をリセットして一旦隠す。
     // 解説が確定した時点（キャッシュ/生成成功）で showRating() する。
+    // currentDescriptionText も一旦 null にし、有効な説明文が出るまで評価記録の
+    // 対象が無い状態にする（記事なし・生成失敗のまま rating が押せないように）。
     currentRating = null;
+    currentDescriptionText = null;
     setRatingState(null);
     hideRating();
 
@@ -359,6 +388,7 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
 
     if (cached) {
       setDescription(cached);
+      currentDescriptionText = cached;
       currentJudgeData = { cached: true };
       setDebugInfo(currentJudgeData, isDebugOn());
       if (currentTraceId) {
@@ -370,8 +400,10 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
         }));
         currentDisplayStartMs = Date.now();
         updateTelemetry(currentTraceId, { ts_displayed: currentDisplayStartMs });
-        showRating();  // Issue #17: 有効な解説が出たので 👍 / 👎 を表示
       }
+      // Issue #17: 有効な解説が出たので sampling の有無に関わらず 👍 / 👎 を表示する。
+      // サンプリング外でクリックされた場合は handleRatingClick が trace を遅延発行して記録する。
+      showRating();
     } else {
       setDescriptionLoading();
       const result = await fetchDescription(
@@ -415,6 +447,7 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
             await new Promise((r) => setTimeout(r, 300));
           }
           setDescription(result.description);
+          currentDescriptionText = result.description;
           currentJudgeData = {
             judge_passed: result.judge_passed,
             faithfulness_score: result.faithfulness_score,
@@ -446,8 +479,9 @@ async function handlePosition({ lat, lon, speed, altitude }, password) {
             }));
             currentDisplayStartMs = Date.now();
             updateTelemetry(currentTraceId, { ts_displayed: currentDisplayStartMs });
-            showRating();  // Issue #17: 有効な解説が出たので 👍 / 👎 を表示
           }
+          // Issue #17: 有効な解説が出たので sampling の有無に関わらず 👍 / 👎 を表示する。
+          showRating();
         }
       } else if (result.status === 401) {
         clearPassword();
@@ -474,12 +508,36 @@ function finalizeCurrentTelemetry() {
 }
 
 // === Issue #17: 👍 / 👎 クリック処理 ===
-// 表示中 entry の user_rating を更新する。trace_id が無い（サンプリング外）ときは無視。
-// 同じボタン再タップで null（取り消し）に戻す。updateTelemetry で localStorage に反映し、
-// flush は既存の自動経路（市町村切替・60 秒タイマー）に任せる。
+// 👍 / 👎 は明示フィードバックで貴重なので、サンプリングで間引かず常に記録する。
+// サンプリング外で trace_id が無いときは、その場で trace を遅延発行し、表示中の
+// 市町村に対するテレメトリエントリを積んでから user_rating を更新する。これにより
+// SAMPLE_RATE を下げても評価だけは必ず残る（受動シグナル dwell_ms 等のみ間引く）。
+// 同じボタン再タップで null（取り消し）に戻す。flush は既存の自動経路に任せる。
 function handleRatingClick(clicked) {
-  if (!currentTraceId) return;
-  currentRating = nextRating(currentRating, clicked);
+  const plan = planRatingClick({
+    hasTrace: !!currentTraceId,
+    hasDescription: !!currentDescriptionText && !!currentMuniCd,
+    currentRating,
+    clicked,
+  });
+  // 有効な説明文が表示されていなければ無視（ボタンは hidden のはずだが防御的に）。
+  if (!plan) return;
+
+  // サンプリング外で trace が無ければ、評価を確実に残すため遅延発行してエントリを積む。
+  if (plan.needNewTrace) {
+    currentTraceId = generateTraceId();
+    const now = Date.now();
+    appendTelemetry(buildTelemetryEntry({
+      trace_id: currentTraceId,
+      muni_code: currentMuniCd,
+      description: currentDescriptionText,
+      ts_generated: now,
+    }));
+    currentDisplayStartMs = now;
+    updateTelemetry(currentTraceId, { ts_displayed: now });
+  }
+
+  currentRating = plan.userRating;
   updateTelemetry(currentTraceId, { user_rating: currentRating });
   setRatingState(currentRating);
 }

--- a/public/assets/telemetry.js
+++ b/public/assets/telemetry.js
@@ -107,3 +107,27 @@ export function shouldSample(sampleRate) {
   if (sampleRate <= 0.0) return false;
   return Math.random() < sampleRate;
 }
+
+/**
+ * Issue #17: 👍 / 👎 クリック時にやるべきことを決める純粋関数。
+ *
+ * 👍 / 👎 は明示フィードバックで貴重なため、サンプリングで間引かず常に記録する。
+ * そのためサンプリング外（trace_id 未発行）でクリックされたら、新しい trace を
+ * 発行してエントリを積む必要がある（needNewTrace=true）。有効な説明文が出ていない
+ * （記事なし・生成失敗・切替直後）ときは記録対象が無いので無視する。
+ *
+ * @param {object} args
+ * @param {boolean} args.hasTrace        - 現在 trace_id を保持しているか
+ * @param {boolean} args.hasDescription  - 有効な説明文が表示中か（muni_code と本文が揃っているか）
+ * @param {'up'|'down'|null} args.currentRating - 現在の user_rating
+ * @param {'up'|'down'} args.clicked      - 押されたボタン
+ * @returns {{ needNewTrace: boolean, userRating: ('up'|'down'|null) } | null}
+ *   無視する場合は null。記録する場合は trace 発行要否と次の user_rating を返す。
+ */
+export function planRatingClick({ hasTrace, hasDescription, currentRating, clicked }) {
+  if (!hasDescription) return null;
+  return {
+    needNewTrace: !hasTrace,
+    userRating: nextRating(currentRating, clicked),
+  };
+}

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -4,6 +4,7 @@ import {
   buildTelemetryEntry,
   shouldSample,
   nextRating,
+  planRatingClick,
 } from '../public/assets/telemetry.js';
 
 describe('generateTraceId', () => {
@@ -154,5 +155,45 @@ describe('shouldSample', () => {
     for (let i = 0; i < 1000; i++) if (shouldSample(0.5)) trues++;
     expect(trues).toBeGreaterThan(350);
     expect(trues).toBeLessThan(650);
+  });
+});
+
+describe('planRatingClick (Issue #17 評価は常に記録)', () => {
+  it('説明文が出ていなければ無視する', () => {
+    const plan = planRatingClick({
+      hasTrace: true, hasDescription: false, currentRating: null, clicked: 'up',
+    });
+    expect(plan).toBeNull();
+  });
+
+  it('サンプリング外（trace なし）でも記録する: 新規 trace 発行を要求する', () => {
+    const plan = planRatingClick({
+      hasTrace: false, hasDescription: true, currentRating: null, clicked: 'up',
+    });
+    expect(plan).not.toBeNull();
+    expect(plan.needNewTrace).toBe(true);
+    expect(plan.userRating).toBe('up');
+  });
+
+  it('サンプリング当選（trace あり）では新規 trace を発行しない', () => {
+    const plan = planRatingClick({
+      hasTrace: true, hasDescription: true, currentRating: null, clicked: 'down',
+    });
+    expect(plan.needNewTrace).toBe(false);
+    expect(plan.userRating).toBe('down');
+  });
+
+  it('同じボタン再タップで評価を取り消す（null に戻す）', () => {
+    const plan = planRatingClick({
+      hasTrace: true, hasDescription: true, currentRating: 'up', clicked: 'up',
+    });
+    expect(plan.userRating).toBeNull();
+  });
+
+  it('👍 から 👎 へ切り替えできる', () => {
+    const plan = planRatingClick({
+      hasTrace: true, hasDescription: true, currentRating: 'up', clicked: 'down',
+    });
+    expect(plan.userRating).toBe('down');
   });
 });

--- a/tests/e2e/history.spec.js
+++ b/tests/e2e/history.spec.js
@@ -78,7 +78,12 @@ async function enterHistoryScreen(page) {
 }
 
 test.describe('踏破履歴ビュー E2E', () => {
-  test('diag: 関東タップ前後の内部状態と Canvas hit testing の検証', async ({ page }) => {
+  test('diag: 関東タップ前後の内部状態と Canvas hit testing の検証', async ({ page }, testInfo) => {
+    // この diag テストは page.touchscreen.tap() を使うため、touch 無効の
+    // desktop-chromium では実行できない（hasTouch must be enabled）。
+    // touch 有効プロジェクト（iphone-emulated 等）限定で走らせる。
+    test.skip(!testInfo.project.use.hasTouch, 'touchscreen.tap を使うため touch 有効プロジェクト限定');
+
     const consoleErrors = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());

--- a/tests/e2e/history.spec.js
+++ b/tests/e2e/history.spec.js
@@ -62,6 +62,16 @@ async function enterHistoryScreen(page) {
   // 🗺️ ボタンが表示されるまで待つ
   const historyBtn = page.locator('#history-open');
   await expect(historyBtn).toBeVisible();
+
+  // 配線完了を待ってからクリックする。フッターボタンのリスナは
+  // /api/mapbox-token の取得を含む enterMainApp 内で装着されるため、
+  // ボタン可視〜リスナ装着の間にクリックすると無反応になりうる
+  // （Mapbox 移行で顕在化）。本番コード側でも配線を前倒し済みだが、
+  // テストでも token 応答を待って二重に安全側へ倒す。
+  await page.waitForResponse(
+    (r) => r.url().includes('/api/mapbox-token'),
+    { timeout: 15000 },
+  ).catch(() => { /* トークン取得失敗時もボタンは機能するので続行 */ });
   await historyBtn.click();
 
   await expect(page.locator('#history-screen')).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/main.spec.js
+++ b/tests/e2e/main.spec.js
@@ -72,10 +72,15 @@ test.describe('trip-road メイン画面 E2E', () => {
     await page.locator('#password-submit').click();
     await expect(page.locator('#main-screen')).toBeVisible();
 
+    // skeleton はアプリ起動直後（GPS 確定前・ロード開始前）も hidden なので、
+    // 先に GPS 確定（muni-name が「現在地を取得中...」から変わる）を待たないと
+    // skeleton の hidden 判定が早すぎて、解説ロード前に rating を見にいってしまう。
+    await expect(page.locator('#muni-name')).not.toHaveText('現在地を取得中...', { timeout: 30000 });
+
     // 解説が確定する（skeleton が消える）と rating 行が表示される
     await expect(page.locator('#description-skeleton')).toBeHidden({ timeout: 30000 });
     const rating = page.locator('#tayori-rating');
-    await expect(rating).toBeVisible();
+    await expect(rating).toBeVisible({ timeout: 10000 });
 
     const up = page.locator('#rating-up');
     const down = page.locator('#rating-down');


### PR DESCRIPTION
## 概要
本番 E2E（2026-06-07）で判明したメイン画面初期化まわりの競合を解消する。VSCode 中断後の続き作業で #71（Worker プロンプト）を本番反映した際、フロント E2E を回して発覚した課題への対応。

## 変更点
### fix(rating): 👍/👎 の表示を sampling から分離し、評価を常に記録（コミット 1a5a22a）
- `showRating()` を `if (currentTraceId)` の外へ。有効な解説が出たら sampling の有無に関わらず常時表示。
- `handleRatingClick`: trace が無ければ遅延発行して必ず記録（受動テレメトリ dwell_ms 等のみ sampling 対象）。これで将来 `TELEMETRY_SAMPLE_RATE` を下げても 👍/👎 が消えず、評価も失われない。
- 判断ロジックを純粋関数 `planRatingClick`（telemetry.js）へ切り出し、ユニットテスト追加。
- 起動時のキャッシュ表示経路でも rating 表示。

### fix(map): フッター配線を Mapbox トークン取得待ちより前へ（同 1a5a22a）
- `showMainScreen()` 直後にフッターボタン（⚙️/⛰️/👍👎/🗺️）のリスナを装着。地図依存の hillshade 初期適用のみ `initMap` 後に残す。
- ボタン可視〜リスナ装着の間の無反応ウィンドウ（約375ms、Mapbox 移行 #69 で顕在化）を解消。実機の遅い回線でも表示直後の 🗺️ タップが効く。

### test(e2e): 待機条件の追加と diag の限定（コミット 01cca42 / ca6f401）
- `main.spec` test#5: GPS 確定（muni-name）待ちを追加し、解説ロード後に rating を検証。
- `history.spec`: `enterHistoryScreen` で `/api/mapbox-token` 応答を待ってからクリック（配線完了の二重安全策）。
- history diag: `touchscreen.tap` 必須のため hasTouch 有効プロジェクト限定に skip。

## テスト
- Vitest: **145 passed**（planRatingClick 5件追加）。
- 本番 E2E（フロント本番反映後、chromium-iphone + desktop-chromium）:
  - rating test#5（Issue #17）: PASS
  - history ナビゲーション（オープン / レベル0→1 / 関東→神奈川→詳細モーダル）: PASS（diag は desktop で skip、iphone で PASS）
- 本番反映: フロント Pages デプロイ済（Deployment `1d3e1147`）、本番アセットに反映確認済。

## 既知の残課題（本PR対象外）
- `main.spec` test#4「visibilitychange 後の地図サイズ」が chromium-iphone で失敗 → Mapbox の別件として #73 を起票。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
