### PR TITLE
fix(e2e): test#4に土地のたより生成完了の待機を追加しflakyを解消

### DIFF
--- a/tests/e2e/main.spec.js
+++ b/tests/e2e/main.spec.js
@@ -114,7 +114,15 @@ test.describe('trip-road メイン画面 E2E', () => {
     await page.locator('#password-input').fill(APP_PASSWORD);
     await page.locator('#password-submit').click();
     await expect(page.locator('#main-screen')).toBeVisible();
-    await page.waitForTimeout(2000);  // 地図初期描画
+
+    // 土地のたより生成パイプラインの完了を待つ（Issue #73）。
+    // .bottom-card の高さは skeleton→生成中→判定中→確定 の遷移で変わり、
+    // ResizeObserver が --card-height 経由で #map の高さも動かすため、
+    // 遷移中に before/after を計測すると visibilitychange と無関係に高さ差が出る。
+    // skeleton は GPS 確定前も hidden のため、先に muni-name 確定を待つ（test#5 と同じ順序）。
+    await expect(page.locator('#muni-name')).not.toHaveText('現在地を取得中...', { timeout: 30000 });
+    await expect(page.locator('#description-skeleton')).toBeHidden({ timeout: 30000 });
+    await page.waitForTimeout(500);  // カード高さ確定後の ResizeObserver → map.resize 反映待ち
 
     // 地図サイズ取得（before）
     const mapBefore = await page.locator('#map').boundingBox();
@@ -129,7 +137,7 @@ test.describe('trip-road メイン画面 E2E', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
 
-    await page.waitForTimeout(500);  // map.invalidateSize の setTimeout 100ms 待ち
+    await page.waitForTimeout(500);  // map.resize の setTimeout 100ms 待ち（Mapbox GL JS v3）
 
     // 地図サイズが大きく変わっていないこと
     const mapAfter = await page.locator('#map').boundingBox();


### PR DESCRIPTION
## 概要
Issue #73（E2E test#4「visibilitychange 後も地図サイズが正しく保たれる」が chromium-iphone-emulated で失敗）の修正。

## 根因（証拠ベースで確定）
- test#4 だけが「土地のたより」生成パイプラインの完了を待たず、固定 2000ms 待機のみで地図高さの before/after を計測していた（test#3/#5 には skeleton 待機がある）。
- `.bottom-card` の高さは skeleton→生成中→判定中→確定 のフェーズ遷移で変わり、ResizeObserver が `--card-height` を更新して `#map` の高さも連動する設計（`public/assets/map.js:277-285`、`app.css:178`）。
- 失敗時の実測: mapBefore.height=479px → mapAfter.height=381px（差 98px）。失敗時スクリーンショットは「✓ 内容を確認しています…」（judging フェーズ途中）を捉えており、visibilitychange ではなくカード高さ変化が原因と確定。
- Mapbox GL JS v3 の resize 実バグではない（同一条件のリトライで pass する flaky 挙動とも整合）。

## 変更内容
- test#4 に test#5 と同じ待機（muni-name 確定 → `#description-skeleton` 非表示、各 timeout 30s）を追加してから計測を開始。
- 旧 Leaflet 時代のコメント `map.invalidateSize` を `map.resize`（Mapbox GL JS v3）に更新。

## 検証
- 修正後、`--repeat-each=3 --retries=0` で 3/3 pass（34.8s）。修正前は 1回目 fail → retry pass の flaky。

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4EhfDkTZhfDif4NN1jNMR
